### PR TITLE
Read length window filtering before groot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ files), and the patch version is typically incremented for any set of changes
 committed to the master branch that does not trigger any of the aforementioned
 situations.
 
+## [0.3.3] Unreleased
+### Changed
+- Added read length window filter before groot alignment step.
+
 
 ## [0.3.2-dev]
 ### Added

--- a/Snakefile
+++ b/Snakefile
@@ -14,7 +14,7 @@ from snakemake.utils import min_version
 min_version("5.2.0")  # TODO: Bump version requirement when Snakemake is pathlib compatible
 
 
-stag_version = "0.3.2-dev"
+stag_version = "0.3.3-dev"
 
 onstart:
     print("\n".join([

--- a/config.yaml
+++ b/config.yaml
@@ -142,3 +142,5 @@ humann2:
 groot:
     db: "arg-annot"          # Used when downloading and indexing DB with "create_groot_index" rule
     index: ""                # [Required] Path to groot index
+    minlength: 110           # Minlength for groot index
+    maxlength: 125           # Maxlength for groot index

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,9 +56,9 @@ author = 'Fredrik Boulund, Lisa Olsson'
 # built documents.
 #
 # The short X.Y version.
-version = '0.3.2'
+version = '0.3.3'
 # The full version, including alpha/beta/rc tags.
-release = '0.3.2-dev'
+release = '0.3.3-dev'
 
 # reStructuredText prolog contains a string of reStructuredText that will be
 # included at the beginning of every source file that is read.

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -328,5 +328,8 @@ containing two files and two subfolders::
 The ``<sample>.groot.bam`` file contains mapping results against all resistance
 gene graphs, and the ``<sample>.groot_report.tsv`` file contains a list of
 observed antibiotic resistance genes in the sample. The two subfolders contain 
-all mapped graphs and coverage plots of all detected antibiotic resisatance genes.
+all mapped graphs and coverage plots of all detected antibiotic resistance genes.
 
+The read lengths input to `groot`_ must conform to the settings used during
+`groot`_ database construction. The length window can be configured in the
+config file.

--- a/rules/antibiotic_resistance/groot.smk
+++ b/rules/antibiotic_resistance/groot.smk
@@ -93,12 +93,13 @@ rule groot_align:
             in1={input.read1} \
             in2={input.read2} \
             out1={output.read1} \
-            out2={output.read2}
+            out2={output.read2} \
             minlength={params.minlength} \
             maxlength={params.maxlength} \
-            > {log.reformat}
+            tossbrokenreads \
+            2> {log.reformat}
         groot align \
-            --fastq {input.read1},{input.read2} \
+            --fastq {output.read1},{output.read2} \
             --graphDir {output.graphs} \
             --indexDir {params.index} \
             --processors {threads} \

--- a/rules/antibiotic_resistance/groot.smk
+++ b/rules/antibiotic_resistance/groot.smk
@@ -67,11 +67,14 @@ rule groot_align:
         read1=OUTDIR/"filtered_human/{sample}_R1.filtered_human.fq.gz",
         read2=OUTDIR/"filtered_human/{sample}_R2.filtered_human.fq.gz",
     output:
+        read1=temp(OUTDIR/"groot/{sample}/{sample}_R1.size_window.fq.gz"),
+        read2=temp(OUTDIR/"groot/{sample}/{sample}_R2.size_window.fq.gz"),
         bam=OUTDIR/"groot/{sample}/{sample}.groot_aligned.bam",
         report=OUTDIR/"groot/{sample}/{sample}.groot_report.tsv",
         plots=directory(OUTDIR/"groot/{sample}/groot-plots"),
         graphs=directory(OUTDIR/"groot/{sample}/groot-graphs"),
     log:
+        reformat=str(LOGDIR/"groot/{sample}.reformat.log"),
         align=str(LOGDIR/"groot/{sample}.groot_align.log"),
         report=str(LOGDIR/"groot/{sample}.groot_report.log"),
     shadow:
@@ -81,9 +84,19 @@ rule groot_align:
     threads:
         8
     params:
-        index=groot_config["index"]
+        index=groot_config["index"],
+        minlength=groot_config["minlength"],
+        maxlength=groot_config["maxlength"],
     shell:
         """
+        reformat.sh \
+            in1={input.read1} \
+            in2={input.read2} \
+            out1={output.read1} \
+            out2={output.read2}
+            minlength={params.minlength} \
+            maxlength={params.maxlength} \
+            > {log.reformat}
         groot align \
             --fastq {input.read1},{input.read2} \
             --graphDir {output.graphs} \


### PR DESCRIPTION
Groot is picky about input read lengths matching the settings used during database index construction. This PR ensures all reads presented to groot are in a reasonable length span (defined in config file).