### PR TITLE
Limit parallel humann2 processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ committed to the master branch that does not trigger any of the aforementioned
 situations.
 
 ## [0.3.3] Unreleased
+### Added
+- Added resource limiter for HUMAnN2 due to its intense use of huge temporary
+  files in the output folder. Activated with --resources humann2=X, where X is
+  the max number of parallel instances of humann2 to run.
 ### Changed
 - Added read length window filter before groot alignment step.
 - Change logdir of remove_human rule to LOGDIR/remove_human instead of

--- a/cluster_configs/rackham/rackham.yaml
+++ b/cluster_configs/rackham/rackham.yaml
@@ -3,7 +3,7 @@ __default__:
     account: "snic2017-7-245"
     partition: "core"
     extra: ""
-    time: "00:15:00"
+    time: "03:00:00"
     n: 2
     stderr: "slurm_logs/slurm-{rule}-{wildcards}.stderr"
     stdout: "slurm_logs/slurm-{rule}-{wildcards}.stdout"
@@ -67,7 +67,7 @@ metaphlan2:
 #############################
 humann2:
     n: 8
-    time: "03:00:00"
+    time: "12:00:00"
 
 #############################
 # Antibiotic resistance

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -293,23 +293,26 @@ HUMAnN2
 :Output folder: ``humann2``
 
 Run `HUMAnN2`_ on the trimmed and filtered reads to produce a functional profile.
-Outputs three files per sample, plus three summaries for all samples::
+Outputs five files per sample, plus three summaries for all samples::
 
+    <sample>.genefamilies_relab.tsv
     <sample>.genefamilies.tsv
+    <sample>.pathabundance_relab.tsv
+    <sample>.pathabundance.tsv
     <sample>.pathcoverage.tsv
-    <sample>.pathabundances.tsv
     
     all_samples.humann2_genefamilies.tsv
     all_samples.humann2_pathcoverage.tsv
     all_samples.humann2_pathabundances.tsv
 
-Note that HUMAnN2 uses the taxonomic profiles produced by MetaPhlAn2, so all
-MetaPhlAn2-associated steps are run regardless of whether it is actually
+Note that HUMAnN2 uses the taxonomic profiles produced by MetaPhlAn2 as input,
+so all MetaPhlAn2-associated steps are run regardless of whether it is actually
 enabled in ``config.yaml`` or not.
 
 HUMAnN2 uses A LOT of temporary disk space in the output folder while running.
-Limit the number of concurrent HUMANn2 processes by using e.g. `--resources
-humann2=3` to tell Snakemake to not run more than three instances in parallel.
+It is possible to limit the number of concurrent HUMANn2 processes by using
+e.g. `--resources humann2=3` to tell Snakemake to not run more than three
+instances in parallel.
 
 
 Antibiotic resistance

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -307,6 +307,10 @@ Note that HUMAnN2 uses the taxonomic profiles produced by MetaPhlAn2, so all
 MetaPhlAn2-associated steps are run regardless of whether it is actually
 enabled in ``config.yaml`` or not.
 
+HUMAnN2 uses A LOT of temporary disk space in the output folder while running.
+Limit the number of concurrent HUMANn2 processes by using e.g. `--resources
+humann2=3` to tell Snakemake to not run more than three instances in parallel.
+
 
 Antibiotic resistance
 *********************

--- a/rules/functional_profiling/humann2.smk
+++ b/rules/functional_profiling/humann2.smk
@@ -77,6 +77,8 @@ rule humann2:
         "../../envs/biobakery.yaml"
     threads:
         8
+    resources:
+        humann2=1
     params:
         outdir=OUTDIR/"humann2",
         nucleotide_db=h_config["nucleotide_db"],


### PR DESCRIPTION
HUMAnN2 creates huge temporary files in the output folder (see #75). This PR does not solve the issue, but allows to limit the number of parallel humann2 rules to limit the impact. Run the workflow with `--resources humann2=X` to limit the number of rules executing in parallel to `X`. 

Because it seems it's impossible to change the temporary folder of HUMAnN2, it will keep working with all these files in the output folder, which is typically located on the slow shared file system, so I also increased the allocated time for humann2 jobs on Rackham to 12h instead of just 3h as it was previously.