### PR TITLE
Generalize join tables

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -103,6 +103,8 @@ kaiju:
     nodes: ""                # [Required] Path to Kaiju taxonomy nodes.dmp
     names: ""                # [Required] Path to Kaiju taxonomy names.dmp
     levels: ["species", "genus", "family"]    # Level(s) to summarize Kaiju report to, pick from: superkingdom, phylum, class, order, family, genus, species
+    feature_column: "taxon_name"    # Feature column to use in all_samples summary
+    value_column: "percent"    # Value column top use in all_samples summary. Options are typically "percent" or "reads"
 
 kraken2:
     db: ""                   # [Required] Path to Kraken2 DB folder

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -268,13 +268,16 @@ Kaiju
 :Output folder: ``kaiju``
 
 Run `Kaiju`_ on the trimmed and filtered reads to produce a taxonomic profile.
-Outputs four files per sample, plus a summary HTML Krona report with the
-profiles of all samples (``all_samples.kaiju.krona.html``). The four per-sample
-output files are::
+Outputs several files per sample (one per taxonomic level specified in the
+config), plus two files that combine all samples in the run: an HTML Krona
+report with the profiles of all samples and a TSV table per taxonomic level.
+The output files are::
 
     <sample>.kaiju
     <sample>.kaiju.<level>.tsv
     <sample>.krona
+    all_samples.kaiju.krona.html
+    all_samples.kaiju.<level>.tsv
 
 Kraken2
 -------

--- a/report/kaiju_table.rst
+++ b/report/kaiju_table.rst
@@ -1,0 +1,1 @@
+TSV table with Kaiju results for all samples.

--- a/rules/taxonomic_profiling/kraken2.smk
+++ b/rules/taxonomic_profiling/kraken2.smk
@@ -256,11 +256,13 @@ rule join_bracken:
         "../../envs/stag-mwc.yaml"
     params:
         value_column="fraction_total_reads",
+        feature_column="name",
     shell:
         """
-        scripts/join_bracken_tables.py \
+        scripts/join_tables.py \
             --outfile {output.table} \
             --value-column {params.value_column} \
+            --feature-column {params.feature_column} \
             {input.bracken} \
             2>&1 > {log}
         """
@@ -280,11 +282,13 @@ rule join_bracken_filtered:
         "../../envs/stag-mwc.yaml"
     params:
         value_column="fraction_total_reads",
+        feature_column="name",
     shell:
         """
-        scripts/join_bracken_tables.py \
+        scripts/join_tables.py \
             --outfile {output.table} \
             --value-column {params.value_column} \
+            --feature-column {params.feature_column} \
             {input.bracken} \
             2>&1 > {log}
         """

--- a/rules/taxonomic_profiling/metaphlan2.smk
+++ b/rules/taxonomic_profiling/metaphlan2.smk
@@ -109,11 +109,11 @@ rule plot_metaphlan2_heatmap:
     input:
         f"{OUTDIR}/metaphlan2/all_samples.metaphlan2.txt",
     output:
-        pdf=report(f"{OUTDIR}/metaphlan2/all_samples.{mpa_config['heatmap']['level']}_top{mpa_config['heatmap']['topN']}.pdf",
+        pdf=report(f"{OUTDIR}/metaphlan2/all_samples.{{level}}_top{{topN}}.pdf",
                    category="Taxonomic profiling",
                    caption="../../report/metaphlan2.rst"),
     log:
-        f"{LOGDIR}/metaphlan2/plot_metaphlan2_heatmap.log",
+        f"{LOGDIR}/metaphlan2/plot_metaphlan2_heatmap.{{level}}_top{{topN}}.log",
     shadow:
         "shallow"
     conda:
@@ -122,8 +122,6 @@ rule plot_metaphlan2_heatmap:
         1
     params:
         outfile_prefix=lambda w: f"{OUTDIR}/metaphlan2/all_samples",
-        level=mpa_config["heatmap"]["level"],
-        topN=mpa_config["heatmap"]["topN"],
         pseudocount=mpa_config["heatmap"]["pseudocount"],
         colormap=mpa_config["heatmap"]["colormap"],
         method=mpa_config["heatmap"]["method"],
@@ -133,12 +131,13 @@ rule plot_metaphlan2_heatmap:
         """
         scripts/plot_metaphlan2_heatmap.py \
             --outfile-prefix {params.outfile_prefix} \
-            --level {params.level} \
-            --topN {params.topN} \
+            --level {wildcards.level} \
+            --topN {wildcards.topN} \
             --pseudocount {params.pseudocount} \
             --colormap {params.colormap} \
             --method {params.method} \
             --metric {params.metric} \
+            --force \
             {input} \
             2> {log}
         """

--- a/scripts/join_tables.py
+++ b/scripts/join_tables.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-""" Join Bracken tables """
+"""Join per sample feature tables into a large combined table."""
 __author__ = "Fredrik Boulund"
 __date__ = "2020"
-__version__ = "0.2"
+__version__ = "1.0"
 
 from sys import argv, exit
 from functools import reduce, partial
@@ -14,13 +14,20 @@ import pandas as pd
 
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("BRACKEN", nargs="+",
-            help="Bracken TSV table with columns: name, taxonomy_id, taxonomy_lvl, fraction_total_reads.")
+    parser.add_argument("TABLE", nargs="+",
+            help="TSV table with columns headers.")
+    parser.add_argument("-f", "--feature-column", dest="feature_column",
+            default="name",
+            help="Column header of feature column to use, "
+                 "typically containing taxa names. "
+                 "Select several columns by separating with comma (e.g. name,taxid) "
+                 "[%(default)s].")
     parser.add_argument("-c", "--value-column", dest="value_column",
             default="fraction_total_reads",
-            help="Value column to use [%(default)s].")
+            help="Column header of value column to use, "
+                 "typically containing counts or abundances [%(default)s].")
     parser.add_argument("-o", "--outfile", dest="outfile",
-            default="bracken_joined.tsv",
+            default="joined_table.tsv",
             help="Outfile name [%(default)s].")
     parser.add_argument("-n", "--fillna", dest="fillna", metavar="FLOAT",
             default=0.0,
@@ -34,13 +41,15 @@ def parse_args():
     return parser.parse_args()
 
 
-def main(bracken_files, value_column, outfile, fillna):
+def main(table_files, feature_column, value_column, outfile, fillna):
+    feature_columns = feature_column.split(",")
+
     tables = []
-    for bracken_file in bracken_files:
-        sample_name = Path(bracken_file).name.split(".")[0]
+    for table_file in table_files:
+        sample_name = Path(table_file).name.split(".")[0]
         tables\
-            .append(pd.read_csv(bracken_file, sep="\t")\
-            .set_index(["name", "taxonomy_id"])\
+            .append(pd.read_csv(table_file, sep="\t")\
+            .set_index(feature_columns)\
             .rename(columns={value_column: sample_name})\
             .loc[:, [sample_name]])  # Ugly hack to get a single-column DataFrame
 
@@ -54,7 +63,7 @@ def main(bracken_files, value_column, outfile, fillna):
 
 if __name__ == "__main__":
     args = parse_args()
-    if len(args.BRACKEN) < 2:
+    if len(args.TABLE) < 2:
         print("Need at least two tables to merge!")
         exit(1)
-    main(args.BRACKEN, args.value_column, args.outfile, args.fillna)
+    main(args.TABLE, args.feature_column, args.value_column, args.outfile, args.fillna)


### PR DESCRIPTION
This PR generalizes `join_bracken_tables.py` into a more general table joining script that is useful also for joining the tables output from other tools. My long-term plan is to make sure the taxonomic profile tables from all methods in StaG have similar output. 