### PR TITLE
Generalize taxprofile tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ situations.
 - Added Bracken abundance estimation on Kraken2 report files; added Bracken to
   the StaG conda environment. Also added Bracken abundance filtering rules so
   users can include/exclude certain taxa.
+- Added "all_samples" summary output files in a more common format for all
+  taxonomic profilers, called `mpa_style`. They are not identical, but very
+  similar, with full lineage listings for all detected taxa.
 
 ### Fixed
 - Fixed bug in Slurm profile handling of cancelled/failed jobs.

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -286,17 +286,26 @@ Kraken2
 
 Run `Kraken2`_ on the trimmed and filtered reads to produce a taxonomic profile. 
 Optionally Bracken can be run to produce abundance profiles for each sample at a
-user-specified taxonomic level. Kraken2 outputs two files per sample::
+user-specified taxonomic level. The Kraken2 module produces the following files::
 
     <sample>.kraken
     <sample>.kreport
+    all_samples.kraken2.tsv
+    all_samples.mpa_style.tsv
 
-The optional Bracken adds additional output files for each sample::
+This modules outputs two tables containing the same information in two formats:
+one is the default Kraken2 output format, the other is a MetaPhlAn2-like format
+(``mpa_style``). The optional Bracken further adds additional output files for
+each sample::
 
     <sample>.<taxonomic_level>.bracken
     <sample>.<taxonomic_level>.filtered.bracken
+    <sample>_bracken.kreport
+    <sample>.bracken.mpa_style.tsv
     all_samples.<taxonomic_level>.bracken.tsv
     all_samples.<taxonomic_level>.filtered.bracken.tsv
+    all_samples.bracken.mpa_style.tsv
+    
 
 MetaPhlAn2
 ----------

--- a/report/bracken_table_mpa.rst
+++ b/report/bracken_table_mpa.rst
@@ -1,0 +1,1 @@
+TSV table with combined and filtered Bracken reports based on the Kraken2 reports, in MetaPhlAn2-like format.

--- a/report/kraken2_table_mpa.rst
+++ b/report/kraken2_table_mpa.rst
@@ -1,0 +1,1 @@
+TSV table with combined and Kraken2 reports, in MetaPhlAn2-like format.

--- a/rules/taxonomic_profiling/kaiju.smk
+++ b/rules/taxonomic_profiling/kaiju.smk
@@ -8,6 +8,9 @@ from snakemake.exceptions import WorkflowError
 localrules:
     download_kaiju_database,
     create_kaiju_krona_plot,
+    kaiju2krona,
+    kaiju_report,
+    join_kaiju_reports,
 
 kaiju_config = config["kaiju"]
 if config["taxonomic_profile"]["kaiju"]:


### PR DESCRIPTION
Generalize output tables from taxonomic profilers to a more common output format, inspired by MetaPhlAn2 output format. One column with taxa description including full lineage, and one column per samples and their respective detected abundance/read counts. 

