### PR TITLE
Enable shortcuts past QC and host_removal

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -60,7 +60,7 @@ report: "report/workflow.rst"
 # Pre-processing
 #############################
 include: "rules/preproc/read_quality.smk"
-include: "rules/preproc/remove_host.smk"
+include: "rules/preproc/host_removal.smk"
 include: "rules/preproc/bbcountunique.smk"
 
 #############################

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,0 +1,44 @@
+Frequently asked questions (FAQ)
+================================
+|full_name| is designed to be fairly flexible. This section answers common
+questions on how to best utilize |full_name|'s flexibility. Please help expand
+this section by making a Pull Request with suggestions.
+
+
+Skip host removal
+*****************
+It is possible to skip host removal. This might be appropriate for example when
+processing environmental samples that do not need host removal. It is
+implemented in |full_name| in a special way: if the user sets ``host_removal:
+False`` in the configuration file then |full_name| will put symlinks to the
+``qc_reads`` output files in the ``host_removal`` output directory. This
+"tricks" Snakemake into thinking that host removal actually occured, enabling
+it to complete the dependency graph to process the data in downstream steps.
+
+
+Using already trimmed and quality controlled sequencing data
+************************************************************
+In some cases your data has already been subjected to adapter and quality
+trimming so you want to skip that step. In |full_name| it is possible to bypass
+both the read QC step and the host removal steps if you need to. In order to do
+so, you must "trick" Snakemake into thinking that those rules have already been
+performed. The easiest way is simply to put symlinks to your input data files
+inside the ``qc_reads`` output directory (or the ``host_removal`` output
+directory), making sure that the fake "output" filenames match the hardcoded
+output filenames from those steps: ``{sample}_{readpair}.fq.gz``.
+
+For example, if your data has already been QC'd. Let's assume your input files
+are located in a folder called ``input``::
+
+   $ ls input
+   sample1_1.fq.gz sample1_2.fq.gz
+
+Now, you want to skip QC but not host removal. Then we need to create the output files
+that Snakemake expects from the QC step::
+
+   $ mkdir -pv output_dir/fastp
+   $ cd output_dir/fastp
+   $ ln -s ../../input/sample1_{1,2}.fq.gz .
+
+Then, make sure to set the pipeline configuration so that QC is not performed:
+``qc_reads: False``.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,7 @@ Gothenburg.
    installation
    running
    modules
+   faq
 
 
 About

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -97,10 +97,10 @@ steps to this limit.
 
     If several people are running StaG-mwc on a shared server or on a shared
     file system, it can be useful to use the ``--conda-prefix`` parameter to
-    use a common folder to store the conda environments created by StaG-mwc,
-    so they can be re-used between different people or analyses. This reduces
-    the risk of producing several copies of the same conda environment in
-    different folders. This is also necessary when running on a cluster where
+    use a common folder to store the conda environments created by StaG-mwc, so
+    they can be re-used between different people or analyses. This reduces the
+    risk of producing several copies of the same conda environment in different
+    folders. This is also often necessary when running on cluster systems where
     paths are usually very deep. Then for example create a folder in your home
     directory and use that with the  ``--conda-prefix`` option.
 
@@ -112,6 +112,7 @@ Another useful command line argument to snakemake is ``--keep-going``. This will
 instruct snakemake to keep going even if a job should fail, e.g. maybe the
 taxonomic profiling step will fail for a sample if the sample contains no assignable
 reads after quality filtering (extreme example).
+
 
 Running on cluster resources
 ****************************

--- a/rules/antibiotic_resistance/groot.smk
+++ b/rules/antibiotic_resistance/groot.smk
@@ -67,11 +67,11 @@ rule create_groot_index:
 rule groot_align:
     """Align reads to groot index."""
     input:
-        read1=OUTDIR/"host_removal/{sample}_R1.host_removal.fq.gz",
-        read2=OUTDIR/"host_removal/{sample}_R2.host_removal.fq.gz",
+        read1=OUTDIR/"host_removal/{sample}_1.fq.gz",
+        read2=OUTDIR/"host_removal/{sample}_2.fq.gz",
     output:
-        read1=temp(OUTDIR/"groot/{sample}/{sample}_R1.size_window.fq.gz"),
-        read2=temp(OUTDIR/"groot/{sample}/{sample}_R2.size_window.fq.gz"),
+        read1=temp(OUTDIR/"groot/{sample}/{sample}_1.size_window.fq.gz"),
+        read2=temp(OUTDIR/"groot/{sample}/{sample}_2.size_window.fq.gz"),
         bam=OUTDIR/"groot/{sample}/{sample}.groot_aligned.bam",
         graphs=directory(OUTDIR/"groot/{sample}/groot-graphs"),
     log:

--- a/rules/assembly/metawrap.smk
+++ b/rules/assembly/metawrap.smk
@@ -60,8 +60,8 @@ if config["binning"]:
 rule assembly:
     """Metagenomic assembly via MetaWRAP."""
     input:
-        read1=f"{OUTDIR}/host_removal/{{sample}}_R1.host_removal.fq.gz",
-        read2=f"{OUTDIR}/host_removal/{{sample}}_R2.host_removal.fq.gz",
+        read1=f"{OUTDIR}/host_removal/{{sample}}_1.fq.gz",
+        read2=f"{OUTDIR}/host_removal/{{sample}}_2.fq.gz",
     output:
         contigs=f"{OUTDIR}/metawrap/assembly/{mw_config['assembler']}/{{sample}}/final_assembly.fasta",
     log:
@@ -95,8 +95,8 @@ rule binning:
     """Metagenomic binning using CONCOCT, MaxBin2, MetaBAT via MetaWRAP."""
     input:
         contigs=f"{OUTDIR}/metawrap/assembly/{mw_config['assembler']}/{{sample}}/final_assembly.fasta",
-        read1=f"{OUTDIR}/host_removal/{{sample}}_R1.host_removal.fq.gz",
-        read2=f"{OUTDIR}/host_removal/{{sample}}_R2.host_removal.fq.gz",
+        read1=f"{OUTDIR}/host_removal/{{sample}}_1.fq.gz",
+        read2=f"{OUTDIR}/host_removal/{{sample}}_2.fq.gz",
     output:
         concoct_bins=f"{OUTDIR}/metawrap/binning/{mw_config['assembler']}/{{sample}}/concoct_bins",
         #maxbin2_bins=f"{OUTDIR}/metawrap/binning/{mw_config['assembler']}/{{sample}}/maxbin2_bins",
@@ -172,8 +172,8 @@ rule blobology:
     input:
         contigs=f"{OUTDIR}/metawrap/assembly/{mw_config['assembler']}/{{sample}}/final_assembly.fasta",
         metawrap_bins=f"{OUTDIR}/metawrap/consolidated_bins/{mw_config['assembler']}/{{sample}}/metawrap",
-        read1=f"{OUTDIR}/host_removal/{{sample}}_R1.host_removal.fq.gz",
-        read2=f"{OUTDIR}/host_removal/{{sample}}_R2.host_removal.fq.gz",
+        read1=f"{OUTDIR}/host_removal/{{sample}}_1.fq.gz",
+        read2=f"{OUTDIR}/host_removal/{{sample}}_2.fq.gz",
     output:
         plots=f"{OUTDIR}/metawrap/blobology/{mw_config['assembler']}/{{sample}}",
     log:

--- a/rules/functional_profiling/humann2.smk
+++ b/rules/functional_profiling/humann2.smk
@@ -61,8 +61,8 @@ rule download_humann2_databases:
 rule humann2:
     """Functional profiling using HUMAnN2."""
     input:
-        read1=OUTDIR/"host_removal/{sample}_R1.host_removal.fq.gz",
-        read2=OUTDIR/"host_removal/{sample}_R2.host_removal.fq.gz",
+        read1=OUTDIR/"host_removal/{sample}_1.fq.gz",
+        read2=OUTDIR/"host_removal/{sample}_2.fq.gz",
         taxonomic_profile=OUTDIR/"metaphlan2/{sample}.metaphlan2.txt",
     output:
         OUTDIR/"humann2/{sample}_genefamilies.tsv",

--- a/rules/mappers/bbmap.smk
+++ b/rules/mappers/bbmap.smk
@@ -57,8 +57,8 @@ for bbmap_config in config["bbmap"]:
     rule:
         """BBMap to {db_name}"""
         input:
-            read1=OUTDIR/"host_removal/{sample}_R1.host_removal.fq.gz",
-            read2=OUTDIR/"host_removal/{sample}_R2.host_removal.fq.gz",
+            read1=OUTDIR/"host_removal/{sample}_1.fq.gz",
+            read2=OUTDIR/"host_removal/{sample}_2.fq.gz",
         output:
             sam=bbmap_output_folder/"{sample}.sam.gz",
             covstats=bbmap_output_folder/"{sample}.covstats.txt",

--- a/rules/mappers/bowtie2.smk
+++ b/rules/mappers/bowtie2.smk
@@ -58,8 +58,8 @@ for bt2_config in config["bowtie2"]:
     rule:
         """Align reads using Bowtie2."""
         input:
-            sample=[OUTDIR/"host_removal/{sample}_R1.host_removal.fq.gz",
-                    OUTDIR/"host_removal/{sample}_R2.host_removal.fq.gz"]
+            sample=[OUTDIR/"host_removal/{sample}_1.fq.gz",
+                    OUTDIR/"host_removal/{sample}_2.fq.gz"]
         output:
             OUTDIR/"bowtie2/{db_name}/{{sample}}.bam".format(db_name=bt2_db_name)
         log:

--- a/rules/preproc/host_removal.smk
+++ b/rules/preproc/host_removal.smk
@@ -69,7 +69,7 @@ if config["host_removal"]:
 
     # Add final output files from this module to 'all_outputs' from the main
     # Snakefile scope. SAMPLES is also from the main Snakefile scope.
-    filtered_host = expand(str(OUTDIR/"host_removal/{sample}_R{readpair}.host_removal.fq.gz"),
+    filtered_host = expand(str(OUTDIR/"host_removal/{sample}_{readpair}.fq.gz"),
             sample=SAMPLES,
             readpair=[1,2])
     host_proportions = str(OUTDIR/"host_removal/host_proportions.tsv")
@@ -90,11 +90,11 @@ if config["host_removal"]:
     rule remove_host:
         """Filter reads matching host database."""
         input:
-            read1=OUTDIR/"fastp/{sample}_R1.qc.fq.gz",
-            read2=OUTDIR/"fastp/{sample}_R2.qc.fq.gz",
+            read1=OUTDIR/"fastp/{sample}_1.fq.gz",
+            read2=OUTDIR/"fastp/{sample}_2.fq.gz",
         output:
-            read1=OUTDIR/"host_removal/{sample}_R1.host_removal.fq.gz",
-            read2=OUTDIR/"host_removal/{sample}_R2.host_removal.fq.gz",
+            read1=OUTDIR/"host_removal/{sample}_1.fq.gz",
+            read2=OUTDIR/"host_removal/{sample}_2.fq.gz",
             host=OUTDIR/"host_removal/{sample}_host.fq.gz",
         log:
             statsfile=str(LOGDIR/"host_removal/{sample}.statsfile.txt"),
@@ -177,7 +177,7 @@ if config["host_removal"]:
             """
 
 else:
-    filtered_host = expand(str(OUTDIR/"host_removal/{sample}_R{readpair}.host_removal.fq.gz"),
+    filtered_host = expand(str(OUTDIR/"host_removal/{sample}_{readpair}.fq.gz"),
             sample=SAMPLES,
             readpair=[1,2])
     all_outputs.extend(filtered_host)
@@ -185,15 +185,14 @@ else:
     localrules:
         skip_remove_host,
 
-    rh_config = config["remove_host"]
     rule skip_remove_host:
-        """Do not filter host sequences"""
+        """Do not remove host sequences"""
         input:
-            read1=OUTDIR/"fastp/{sample}_R1.qc.fq.gz",
-            read2=OUTDIR/"fastp/{sample}_R2.qc.fq.gz",
+            read1=OUTDIR/"fastp/{sample}_1.fq.gz",
+            read2=OUTDIR/"fastp/{sample}_2.fq.gz",
         output:
-            read1=OUTDIR/"host_removal/{sample}_R1.host_removal.fq.gz",
-            read2=OUTDIR/"host_removal/{sample}_R2.host_removal.fq.gz",
+            read1=OUTDIR/"host_removal/{sample}_1.fq.gz",
+            read2=OUTDIR/"host_removal/{sample}_2.fq.gz",
         log:
             stderr=str(LOGDIR/"host_removal/{sample}.stderr.log"),
         conda:

--- a/rules/preproc/read_quality.smk
+++ b/rules/preproc/read_quality.smk
@@ -6,7 +6,7 @@
 if config["qc_reads"]:
     # Add final output files from this module to 'all_outputs' from
     # the main Snakefile scope. SAMPLES is also from the main Snakefile scope.
-    trimmed_qc = expand(str(OUTDIR/"fastp/{sample}_R{readpair}.qc.fq.gz"),
+    trimmed_qc = expand(str(OUTDIR/"fastp/{sample}_{readpair}.fq.gz"),
             sample=SAMPLES,
             readpair=[1, 2])
     all_outputs.extend(trimmed_qc)
@@ -25,8 +25,8 @@ if config["qc_reads"]:
             read1=INPUTDIR/config["input_fn_pattern"].format(sample="{sample}", readpair="1"),
             read2=INPUTDIR/config["input_fn_pattern"].format(sample="{sample}", readpair="2")
         output:
-            read1=OUTDIR/"fastp/{sample}_R1.qc.fq.gz",
-            read2=OUTDIR/"fastp/{sample}_R2.qc.fq.gz",
+            read1=OUTDIR/"fastp/{sample}_1.fq.gz",
+            read2=OUTDIR/"fastp/{sample}_2.fq.gz",
             json=LOGDIR/"fastp/{sample}.fastp.json",
             html=LOGDIR/"fastp/{sample}.fastp.html",
         log:

--- a/rules/taxonomic_profiling/kaiju.smk
+++ b/rules/taxonomic_profiling/kaiju.smk
@@ -67,8 +67,8 @@ rule download_kaiju_database:
 
 rule kaiju:
     input:
-        read1=OUTDIR/"host_removal/{sample}_R1.host_removal.fq.gz",
-        read2=OUTDIR/"host_removal/{sample}_R2.host_removal.fq.gz",
+        read1=OUTDIR/"host_removal/{sample}_1.fq.gz",
+        read2=OUTDIR/"host_removal/{sample}_2.fq.gz",
     output:
         kaiju=OUTDIR/"kaiju/{sample}.kaiju",
     log:

--- a/rules/taxonomic_profiling/metaphlan2.smk
+++ b/rules/taxonomic_profiling/metaphlan2.smk
@@ -44,8 +44,8 @@ if config["taxonomic_profile"]["metaphlan2"]:
 rule metaphlan2:
     """Taxonomic profiling using MetaPhlAn2."""
     input:
-        read1=OUTDIR/"host_removal/{sample}_R1.host_removal.fq.gz",
-        read2=OUTDIR/"host_removal/{sample}_R2.host_removal.fq.gz",
+        read1=OUTDIR/"host_removal/{sample}_1.fq.gz",
+        read2=OUTDIR/"host_removal/{sample}_2.fq.gz",
     output:
         bt2_out=OUTDIR/"metaphlan2/{sample}.bowtie2.bz2",
         mpa_out=OUTDIR/"metaphlan2/{sample}.metaphlan2.txt",


### PR DESCRIPTION
I think a better way to implement DAG shortcut past QC could be to let the workflow do the symlinking, like in the implementation to allow skipping host_removal... 

I found some issues with the kraken2 bracken rules, so these commits are still important.