### PR TITLE
Update HUMAnN2 to 2.8, MPA2 to 2.96.1, and other tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,16 +24,17 @@ situations.
 - Added the possibility to run in Singularity with conda using 
   `--use-singularity --use-conda`.
 - Added more MetaPhlAn2 data in output report.
-- Added rule to automatically download KrakenTools by Jennifer Lu.
+- Added HUMAnN2 summary tables to output report.
 - Added combined table and Krona plot for Kraken2 to output report.
 - Added metagenomic assembly, binning and "blobology", using MEGAHIT or SPAdes,
-  with binning using CONCOCT and MetaBat, implemented via MetaWrap.
-- Added Jennifer Lu's KrakenTools under the MIT license.
-- Added some basic syntax validation tests in CircleCI
-- Added possibility to skip host removal, will symlink QC'd files into the host
-  removal output directory so Snakemake can continue without performing host
-  removal.
-- Added MultiQC.
+  with binning using CONCOCT and MetaBat (MaxBin2 is not working), implemented
+  via MetaWrap.
+- Added KrakenTools from Jennifer Lu under the MIT license.
+- Added basic syntax and DAG validation test in CircleCI
+- Added possibility to skip read QC and/or host removal: will symlink relevant files
+  files into the relevant output directories so Snakemake can continue
+  without performing read QC and/or host removal.
+- Added MultiQC, mainly to summarize fastp logs.
 - Added Bracken abundance estimation on Kraken2 report files; added Bracken to
   the StaG conda environment. Also added Bracken abundance filtering rules so
   users can include/exclude certain taxa.
@@ -44,48 +45,49 @@ situations.
 ### Fixed
 - Fixed bug in Slurm profile handling of cancelled/failed jobs.
 - MetaPhlAn2 rule now correctly detect if no database path has been entered in
-  config file.
+  the config file.
+- HUMAnN2 rule now correctly detects if no database path has been entered in
+  the config file.
 
 ### Changed
 - Updated Python to 3.7 in main stag-mwc conda environment.
+- Updated Kaiju to 1.7.2.
+- Updated BBMap to 38.68.
+- Updated sambamba to 0.7.0.
+- Updated Kraken2 to 2.0.8_beta.
+- Updated seaborn to 0.8.1, added fastcluster to main stag-mwc conda env, installed via pip.
+- Updated MetaPhlAn2 to 2.96.1.
+- Updated HUMAnN2 to 2.8.1.
+- Updated GROOT to v0.8.5.
+- Updated plot_metaphlan2_heatmap.py to 0.3.
 - Added read length window filter before groot alignment step.
 - Change logdir of remove_human rule to LOGDIR/remove_human instead of
   OUTDIR/logs/remove_human.
 - Improved make_count_table.py so it can use TSV annotation files with multiple
   columns. Added config setting for which columns to include.
-- Updated GROOT to v0.8.5.
 - Cleaned up sketch comparison cluster heatmap plotting script, making it more 
   robust to variations in output from different BBTools versions.
 - Changed the call to merge_metaphlan_tables.py due to undocumented
   CLI change in latest conda version.
-- Updated Kaiju to 1.7.2.
 - Changed Kaiju summary report output filenames.
-- Updated BBMap to 38.68.
-- Updated sambamba to 0.7.0.
-- Updated Kraken2 to 2.0.8_beta.
-- Updated seaborn to 0.8.1, added fastcluster to main stag-mwc conda env, installed via pip.
-- Updated MetaPhlAn2 to 2.9.21.
 - Split biobakery environment into metaphlan2 and humann2 so users only
   interested in MetaPhlAn2 do not have to download the huge HUMAnN2.
 - Replaced the outdated metaphlan_hclust_heatmap.py with a custom
-  plot_metaphlan2_heatmap.py script. Required splitting merge_metaphlan
+  plot_metaphlan2_heatmap.py script.
 - Defined some low-impact summary and plotting rules as localrules.
-- Modified preprocessing rule definitions so they are conditionally included based on
-  config settings: this enables arbitrary starting points in the DAG by specifying
-  input dir and input filename pattern according to where the users wants to start the
-  workflow from (e.g. from the output_dir/filtered_human folder, if FASTQ files already
-  have been preprocessed by another workflow). 
 - Reworded all rules relating to human removal to "host removal", and changed output folder
   structure accordingly.
 - Renamed output folder and file names for quality and adapter trimming.
 - Set Kraken2 --confidence to 0.1 by default.
+- Adjusted HUMAnN2 cores to 20 (up from 8).
+- Adjusted MetaPhlAn2 cores to 5 (up from 4).
 
 
 ### Removed
 - Removed outdated database download rules for Centrifuge, MetaPhlAn2, Kaiju,
   Kraken2, HUMAnN2.
 - Replaced FastQC + BBDuk with fastp adapter trimming and quality filtering.
-- Removed Centrifuge
+- Removed support for Centrifuge
 
 
 ## [0.3.2-dev]

--- a/envs/humann2.yaml
+++ b/envs/humann2.yaml
@@ -4,5 +4,5 @@ channels:
     - conda-forge
     - defaults
 dependencies:
-    - humann2 =0.11.2
+    - humann2 =2.8.1
     - krona =2.7.1

--- a/envs/metaphlan2.yaml
+++ b/envs/metaphlan2.yaml
@@ -4,5 +4,5 @@ channels:
     - conda-forge
     - defaults
 dependencies:
-    - metaphlan2 =2.9.21
+    - metaphlan2 =2.96.1
     - krona =2.7.1

--- a/report/humann2_table.rst
+++ b/report/humann2_table.rst
@@ -1,0 +1,1 @@
+Functional profile table from HUMAnN2.

--- a/scripts/plot_metaphlan2_heatmap.py
+++ b/scripts/plot_metaphlan2_heatmap.py
@@ -2,7 +2,7 @@
 """Plot MetaPhlAn2 heatmap"""
 __author__ = "Fredrik Boulund"
 __date__ = "2019"
-__version__ = "0.2"
+__version__ = "0.3"
 
 from sys import argv, exit
 from collections import defaultdict
@@ -59,7 +59,7 @@ def parse_args():
                  "see scipy.cluster.hierarchy.linkage docs [%(default)s].")
     parser.add_argument("-m", "--metric",
             default="euclidean",
-            help="Distance metroc to use, "
+            help="Distance metric to use, "
                  "see scipy.spatial.distance.pdist docs [%(default)s].")
     parser.add_argument("-L", "--loglevel", choices=["INFO", "DEBUG"],
             default="INFO",
@@ -81,11 +81,19 @@ def parse_mpa_table(mpa_tsv):
     with open(mpa_tsv) as f:
         firstline = f.readline()
         if firstline.startswith("#mpa"):
-            skiprows = 1
+            second_line = f.readline()
+            third_line = f.readline()
+            if third_line.startswith("#SampleID"):
+                skiprows = 3
+            else:
+                skiprows = 1
             dropcols = ["clade_name", "NCBI_tax_id"]
         elif firstline.startswith("#clade_name"):
             skiprows = 0
             dropcols = ["#clade_name", "NCBI_tax_id"]
+        elif firstline.startswith("clade_name"):
+            skiprows = 0
+            dropcols = ["clade_name", "NCBI_tax_id"]
         elif firstline.startswith("ID"):
             skiprows = 0
             dropcols = ["ID"]


### PR DESCRIPTION
Lots of tweaks related to MPA2 and HUMAnN2. A work-around for formatting incompatibilities between the recent MPA2 version and the slightly older HUMAnN2 is there as well. 

It is important that MPA2 is run using the older v20_m200 database instead of the most recent one.