### PR TITLE
Tsv to txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ situations.
 - Updated HUMAnN2 to 2.8.1.
 - Updated GROOT to v0.8.5.
 - Updated plot_metaphlan2_heatmap.py to 0.3.
+- Changed output filenames ending with `.tsv` to `.txt` to avoid pretty HTML
+  representations in report.
 - Replaced BBMap-based host removal with Kraken2, substantially reducing time
   and resources requirements. 
 - Added read length window filter before groot alignment step.

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -64,7 +64,7 @@ proportion data is also provided::
     <sample>.host_{1,2}.fq.gz
     host_barplot.pdf
     host_histogram.pdf
-    host_proportions.tsv
+    host_proportions.txt
 
 .. note::
 
@@ -228,7 +228,7 @@ file to summarize on. The column names need to be assigned as a string of
 comma-separated column names. They must match exactly to the column names
 defined in the annotation file. This is configured in ``config.yaml``. The
 script outputs one file per column, with output filename matching
-``counts.<column_name>.tsv``. The count table feature is activated by entering
+``counts.<column_name>.txt``. The count table feature is activated by entering
 an annotation filename in the relevant section of the configuration file,
 e.g.::
 
@@ -259,7 +259,7 @@ The featureCounts module outputs several files::
 
     all_samples.featureCounts
     all_samples.featureCounts.summary
-    all_samples.featureCounts.table.tsv
+    all_samples.featureCounts.table.txt
 
 The first two files are the default output files from `featureCounts`_, and the
 third file is a simplified tab-separated table with count per annotation, in a
@@ -289,10 +289,10 @@ report with the profiles of all samples and a TSV table per taxonomic level.
 The output files are::
 
     <sample>.kaiju
-    <sample>.kaiju.<level>.tsv
+    <sample>.kaiju.<level>.txt
     <sample>.krona
     all_samples.kaiju.krona.html
-    all_samples.kaiju.<level>.tsv
+    all_samples.kaiju.<level>.txt
 
 Kraken2
 -------
@@ -305,8 +305,8 @@ user-specified taxonomic level. The Kraken2 module produces the following files:
 
     <sample>.kraken
     <sample>.kreport
-    all_samples.kraken2.tsv
-    all_samples.mpa_style.tsv
+    all_samples.kraken2.txt
+    all_samples.mpa_style.txt
 
 This modules outputs two tables containing the same information in two formats:
 one is the default Kraken2 output format, the other is a MetaPhlAn2-like format
@@ -316,10 +316,10 @@ each sample::
     <sample>.<taxonomic_level>.bracken
     <sample>.<taxonomic_level>.filtered.bracken
     <sample>_bracken.kreport
-    <sample>.bracken.mpa_style.tsv
-    all_samples.<taxonomic_level>.bracken.tsv
-    all_samples.<taxonomic_level>.filtered.bracken.tsv
-    all_samples.bracken.mpa_style.tsv
+    <sample>.bracken.mpa_style.txt
+    all_samples.<taxonomic_level>.bracken.txt
+    all_samples.<taxonomic_level>.filtered.bracken.txt
+    all_samples.bracken.mpa_style.txt
     
 
 MetaPhlAn2
@@ -354,15 +354,15 @@ HUMAnN2
 Run `HUMAnN2`_ on the trimmed and filtered reads to produce a functional profile.
 Outputs five files per sample, plus three summaries for all samples::
 
-    <sample>.genefamilies_relab.tsv
-    <sample>.genefamilies.tsv
-    <sample>.pathabundance_relab.tsv
-    <sample>.pathabundance.tsv
-    <sample>.pathcoverage.tsv
+    <sample>.genefamilies_relab.txt
+    <sample>.genefamilies.txt
+    <sample>.pathabundance_relab.txt
+    <sample>.pathabundance.txt
+    <sample>.pathcoverage.txt
     
-    all_samples.humann2_genefamilies.tsv
-    all_samples.humann2_pathcoverage.tsv
-    all_samples.humann2_pathabundances.tsv
+    all_samples.humann2_genefamilies.txt
+    all_samples.humann2_pathcoverage.txt
+    all_samples.humann2_pathabundances.txt
 
 Note that HUMAnN2 uses the taxonomic profiles produced by MetaPhlAn2 as input,
 so all MetaPhlAn2-associated steps are run regardless of whether it is actually
@@ -395,12 +395,12 @@ produce antibiotic resistance gene profiles. Outputs one subfolder per sample,
 containing two files and two subfolders::
 
     <sample>/<sample>.groot_aligned.bam
-    <sample>/<sample>.groot_report.tsv
+    <sample>/<sample>.groot_report.txt
     <sample>/<sample>/groot-graphs
     <sample>/<sample>/groot-plots
 
 The ``<sample>.groot.bam`` file contains mapping results against all resistance
-gene graphs, and the ``<sample>.groot_report.tsv`` file contains a list of all
+gene graphs, and the ``<sample>.groot_report.txt`` file contains a list of all
 observed antibiotic resistance genes in the sample. The two subfolders contain 
 all mapped graphs and coverage plots of all detected antibiotic resistance genes.
 

--- a/rules/antibiotic_resistance/groot.smk
+++ b/rules/antibiotic_resistance/groot.smk
@@ -20,7 +20,7 @@ if config["antibiotic_resistance"]:
 
     groot_outputs = expand(str(OUTDIR/"groot/{sample}/{sample}.{output_type}"),
             sample=SAMPLES,
-            output_type=("groot_aligned.bam", "groot_report.tsv"))
+            output_type=("groot_aligned.bam", "groot_report.txt"))
     all_outputs.extend(groot_outputs)
 
     citations.add(publications["GROOT"])
@@ -107,7 +107,7 @@ rule groot_report:
     input:
         bam=OUTDIR/"groot/{sample}/{sample}.groot_aligned.bam",
     output:
-        report=OUTDIR/"groot/{sample}/{sample}.groot_report.tsv",
+        report=OUTDIR/"groot/{sample}/{sample}.groot_report.txt",
         plots=directory(OUTDIR/"groot/{sample}/groot-plots"),
     log:
         report=str(LOGDIR/"groot/{sample}.groot_report.log"),

--- a/rules/functional_profiling/humann2.smk
+++ b/rules/functional_profiling/humann2.smk
@@ -22,11 +22,11 @@ if config["functional_profile"]["humann2"]:
 
     # Add HUMAnN2 output files to 'all_outputs' from the main Snakefile scope.
     # SAMPLES is also from the main Snakefile scope.
-    humann2_outputs = expand(str(OUTDIR/"humann2/{sample}_{output_type}.tsv"),
+    humann2_outputs = expand(str(OUTDIR/"humann2/{sample}_{output_type}.txt"),
             sample=SAMPLES,
             output_type=("genefamilies", "pathcoverage", "pathabundance",
                         "genefamilies_{method}".format(method=h_config["norm_method"])))
-    merged_humann2_tables = expand(str(OUTDIR/"humann2/all_samples.humann2_{output_type}.tsv"),
+    merged_humann2_tables = expand(str(OUTDIR/"humann2/all_samples.humann2_{output_type}.txt"),
             output_type=("genefamilies", "pathcoverage", "pathabundance"))
     all_outputs.extend(humann2_outputs)
     all_outputs.extend(merged_humann2_tables)
@@ -60,9 +60,9 @@ rule humann2:
         read2=OUTDIR/"host_removal/{sample}_2.fq.gz",
         taxonomic_profile=OUTDIR/"metaphlan2/{sample}.metaphlan2.txt",
     output:
-        OUTDIR/"humann2/{sample}_genefamilies.tsv",
-        OUTDIR/"humann2/{sample}_pathcoverage.tsv",
-        OUTDIR/"humann2/{sample}_pathabundance.tsv",
+        OUTDIR/"humann2/{sample}_genefamilies.txt",
+        OUTDIR/"humann2/{sample}_pathcoverage.txt",
+        OUTDIR/"humann2/{sample}_pathabundance.txt",
     log:
         stdout=str(LOGDIR/"humann2/{sample}.humann2.stdout.log"),
         stderr=str(LOGDIR/"humann2/{sample}.humann2.stderr.log"),
@@ -106,11 +106,11 @@ rule humann2:
 rule normalize_humann2_tables:
     """Normalize abundance tables from HUMAnN2."""
     input:
-        genefamilies=OUTDIR/"humann2/{sample}_genefamilies.tsv",
-        pathabundance=OUTDIR/"humann2/{sample}_pathabundance.tsv",
+        genefamilies=OUTDIR/"humann2/{sample}_genefamilies.txt",
+        pathabundance=OUTDIR/"humann2/{sample}_pathabundance.txt",
     output:
-        genefamilies=OUTDIR/"humann2/{{sample}}_genefamilies_{method}.tsv".format(method=h_config["norm_method"]),
-        pathabundance=OUTDIR/"humann2/{{sample}}_pathabundance_{method}.tsv".format(method=h_config["norm_method"]),
+        genefamilies=OUTDIR/"humann2/{{sample}}_genefamilies_{method}.txt".format(method=h_config["norm_method"]),
+        pathabundance=OUTDIR/"humann2/{{sample}}_pathabundance_{method}.txt".format(method=h_config["norm_method"]),
     log:
         stdout=str(LOGDIR/"humann2/{sample}.humann2_sample_normalize.stdout.log"),
         stderr=str(LOGDIR/"humann2/{sample}.humann2_sample_normalize.stderr.log"),
@@ -145,19 +145,19 @@ rule normalize_humann2_tables:
 rule join_humann2_tables:
     """Join abundance tables from HUMAnN2."""
     input:
-        genefamilies=expand(str(OUTDIR/"humann2/{{sample}}_genefamilies_{method}.tsv").format(method=h_config["norm_method"]),
+        genefamilies=expand(str(OUTDIR/"humann2/{{sample}}_genefamilies_{method}.txt").format(method=h_config["norm_method"]),
             sample=SAMPLES),
-        pathabundance=expand(str(OUTDIR/"humann2/{{sample}}_genefamilies_{method}.tsv").format(method=h_config["norm_method"]),
+        pathabundance=expand(str(OUTDIR/"humann2/{{sample}}_genefamilies_{method}.txt").format(method=h_config["norm_method"]),
             sample=SAMPLES),
-        pathcoverage=expand(str(OUTDIR/"humann2/{sample}_pathcoverage.tsv"), sample=SAMPLES),
+        pathcoverage=expand(str(OUTDIR/"humann2/{sample}_pathcoverage.txt"), sample=SAMPLES),
     output:
-        genefamilies=report(OUTDIR/"humann2/all_samples.humann2_genefamilies.tsv",
+        genefamilies=report(OUTDIR/"humann2/all_samples.humann2_genefamilies.txt",
                 category="Functional profiling",
                 caption="../../report/humann2_table.rst"),
-        pathabundance=report(OUTDIR/"humann2/all_samples.humann2_pathabundance.tsv",
+        pathabundance=report(OUTDIR/"humann2/all_samples.humann2_pathabundance.txt",
                 category="Functional profiling",
                 caption="../../report/humann2_table.rst"),
-        pathcoverage=report(OUTDIR/"humann2/all_samples.humann2_pathcoverage.tsv",
+        pathcoverage=report(OUTDIR/"humann2/all_samples.humann2_pathcoverage.txt",
                 category="Functional profiling",
                 caption="../../report/humann2_table.rst"),
     log:

--- a/rules/mappers/bbmap.smk
+++ b/rules/mappers/bbmap.smk
@@ -23,13 +23,13 @@ for bbmap_config in config["bbmap"]:
                 db_name=bbmap_config["db_name"],
                 sample=SAMPLES,
                 output_type=("sam.gz", "covstats.txt", "rpkm.txt"))
-        counts_table = expand(str(OUTDIR/"bbmap/{db_name}/counts.{column}.tsv"),
+        counts_table = expand(str(OUTDIR/"bbmap/{db_name}/counts.{column}.txt"),
                 db_name=bbmap_config["db_name"],
                 column=map(str.strip, bbmap_config["counts_table"]["columns"].split(",")))
         featureCounts = expand(str(OUTDIR/"bbmap/{db_name}/all_samples.featureCounts{output_type}"),
                 db_name=bbmap_config["db_name"],
                 sample=SAMPLES,
-                output_type=["", ".summary", ".table.tsv"])
+                output_type=["", ".summary", ".table.txt"])
         all_outputs.extend(bbmap_alignments)
 
         if bbmap_config["counts_table"]["annotations"]:
@@ -101,7 +101,7 @@ for bbmap_config in config["bbmap"]:
                     db_name=bbmap_config["db_name"],
                     sample=SAMPLES)
         output:
-            expand(str(OUTDIR/"bbmap/{db_name}/counts.{column}.tsv"),
+            expand(str(OUTDIR/"bbmap/{db_name}/counts.{column}.txt"),
                     db_name=bbmap_config["db_name"],
                     column=map(str.strip, bbmap_config["counts_table"]["columns"].split(","))
             )
@@ -139,7 +139,7 @@ for bbmap_config in config["bbmap"]:
                     sample=SAMPLES)
         output:
             counts=OUTDIR/"bbmap/{db_name}/all_samples.featureCounts".format(db_name=bbmap_config["db_name"]),
-            counts_table=OUTDIR/"bbmap/{db_name}/all_samples.featureCounts.table.tsv".format(db_name=bbmap_config["db_name"]),
+            counts_table=OUTDIR/"bbmap/{db_name}/all_samples.featureCounts.table.txt".format(db_name=bbmap_config["db_name"]),
             summary=OUTDIR/"bbmap/{db_name}/all_samples.featureCounts.summary".format(db_name=bbmap_config["db_name"]),
         log:
             str(bbmap_logdir/"all_samples.featureCounts.log")

--- a/rules/mappers/bowtie2.smk
+++ b/rules/mappers/bowtie2.smk
@@ -24,13 +24,13 @@ for bt2_config in config["bowtie2"]:
                 sample=SAMPLES,
                 stats=["covstats", "rpkm"],
                 db_name=bt2_db_name)
-        counts_table = expand(str(OUTDIR/"bowtie2/{db_name}/counts.{column}.tsv"),
+        counts_table = expand(str(OUTDIR/"bowtie2/{db_name}/counts.{column}.txt"),
                 db_name=bt2_db_name,
                 column=map(str.strip, bt2_config["counts_table"]["columns"].split(",")))
         featureCounts = expand(str(OUTDIR/"bowtie2/{db_name}/all_samples.featureCounts{output_type}"),
                 db_name=bt2_db_name,
                 sample=SAMPLES,
-                output_type=["", ".summary", ".table.tsv"])
+                output_type=["", ".summary", ".table.txt"])
         all_outputs.extend(bowtie2_alignments)
         all_outputs.extend(bowtie2_stats)
 
@@ -108,7 +108,7 @@ for bt2_config in config["bowtie2"]:
                     db_name=bt2_db_name,
                     sample=SAMPLES)
         output:
-            expand(str(OUTDIR/"bowtie2/{db_name}/counts.{column}.tsv"),
+            expand(str(OUTDIR/"bowtie2/{db_name}/counts.{column}.txt"),
                     db_name=bt2_db_name,
                     column=map(str.strip, bt2_config["counts_table"]["columns"].split(","))
             )
@@ -146,7 +146,7 @@ for bt2_config in config["bowtie2"]:
                     sample=SAMPLES)
         output:
             counts=OUTDIR/"bowtie2/{db_name}/all_samples.featureCounts".format(db_name=bt2_db_name),
-            counts_table=OUTDIR/"bowtie2/{db_name}/all_samples.featureCounts.table.tsv".format(db_name=bt2_db_name),
+            counts_table=OUTDIR/"bowtie2/{db_name}/all_samples.featureCounts.table.txt".format(db_name=bt2_db_name),
             summary=OUTDIR/"bowtie2/{db_name}/all_samples.featureCounts.summary".format(db_name=bt2_db_name),
         log:
             str(LOGDIR/"bowtie2/{db_name}/all_samples.featureCounts.log".format(db_name=bt2_db_name))

--- a/rules/preproc/host_removal.smk
+++ b/rules/preproc/host_removal.smk
@@ -18,7 +18,7 @@ if rh_config:
     filtered_host = expand(str(OUTDIR/"host_removal/{sample}_{readpair}.fq.gz"),
             sample=SAMPLES,
             readpair=[1,2])
-    host_proportions = str(OUTDIR/"host_removal/host_proportions.tsv")
+    host_proportions = str(OUTDIR/"host_removal/host_proportions.txt")
     all_outputs.extend(filtered_host)
     all_outputs.append(host_proportions)
 
@@ -88,7 +88,7 @@ if rh_config:
             barplot=report(OUTDIR/"host_removal/host_barplot.pdf",
                        category="Proportion host reads",
                        caption="../../report/host_barplot.rst"),
-            tsv=report(OUTDIR/"host_removal/host_proportions.tsv",
+           .txt=report(OUTDIR/"host_removal/host_proportions.txt",
                        category="Proportion host reads",
                        caption="../../report/host_proportions.rst"),
         log:
@@ -105,7 +105,7 @@ if rh_config:
                 {input} \
                 --histogram {output.histogram} \
                 --barplot {output.barplot} \
-                --table {output.tsv} \
+                --table {output.txt} \
                 2>&1 > {log}
             """
 

--- a/rules/preproc/host_removal.smk
+++ b/rules/preproc/host_removal.smk
@@ -88,7 +88,7 @@ if rh_config:
             barplot=report(OUTDIR/"host_removal/host_barplot.pdf",
                        category="Proportion host reads",
                        caption="../../report/host_barplot.rst"),
-           .txt=report(OUTDIR/"host_removal/host_proportions.txt",
+            txt=report(OUTDIR/"host_removal/host_proportions.txt",
                        category="Proportion host reads",
                        caption="../../report/host_proportions.rst"),
         log:

--- a/rules/taxonomic_profiling/kaiju.smk
+++ b/rules/taxonomic_profiling/kaiju.smk
@@ -27,8 +27,8 @@ if config["taxonomic_profile"]["kaiju"]:
     # SAMPLES is also from the main Snakefile scope.
     kaiju = expand(str(OUTDIR/"kaiju/{sample}.kaiju"), sample=SAMPLES)
     kaiju_krona = str(OUTDIR/"kaiju/all_samples.kaiju.krona.html")
-    kaiju_reports = expand(str(OUTDIR/"kaiju/{sample}.kaiju.{level}.tsv"), sample=SAMPLES, level=kaiju_config["levels"])
-    kaiju_joined_table = expand(str(OUTDIR/"kaiju/all_samples.kaiju.{level}.tsv"), level=kaiju_config["levels"])
+    kaiju_reports = expand(str(OUTDIR/"kaiju/{sample}.kaiju.{level}.txt"), sample=SAMPLES, level=kaiju_config["levels"])
+    kaiju_joined_table = expand(str(OUTDIR/"kaiju/all_samples.kaiju.{level}.txt"), level=kaiju_config["levels"])
     all_outputs.extend(kaiju)
     all_outputs.extend(kaiju_reports)
     all_outputs.append(kaiju_krona)
@@ -139,7 +139,7 @@ rule kaiju_report:
     input:
         kaiju=OUTDIR/"kaiju/{sample}.kaiju",
     output:
-        OUTDIR/"kaiju/{sample}.kaiju.{level}.tsv",
+        OUTDIR/"kaiju/{sample}.kaiju.{level}.txt",
     log:
         str(LOGDIR/"kaiju/kaiju2table.{sample}.{level}.log")
     shadow: 
@@ -164,9 +164,9 @@ rule kaiju_report:
 
 rule join_kaiju_reports:
     input:
-        expand(str(OUTDIR/"kaiju/{sample}.kaiju.{{level}}.tsv"), sample=SAMPLES),
+        expand(str(OUTDIR/"kaiju/{sample}.kaiju.{{level}}.txt"), sample=SAMPLES),
     output:
-        report(OUTDIR/"kaiju/all_samples.kaiju.{level}.tsv",
+        report(OUTDIR/"kaiju/all_samples.kaiju.{level}.txt",
             category="Taxonomic profiling",
             caption="../../report/kaiju_table.rst")
     log:

--- a/rules/taxonomic_profiling/kraken2.smk
+++ b/rules/taxonomic_profiling/kraken2.smk
@@ -110,7 +110,7 @@ rule kraken_mpa_style:
     input:
         kreport=OUTDIR/"kraken2/{sample}.kreport"
     output:
-       .txt=OUTDIR/"kraken2/{sample}.mpa_style.txt",
+        txt=OUTDIR/"kraken2/{sample}.mpa_style.txt",
     log:
         str(LOGDIR/"kraken2/{sample}.mpa_style.log")
     threads:
@@ -130,7 +130,7 @@ rule kraken_mpa_style:
 
 rule join_kraken2_mpa:
     input:
-       .txt=expand(str(OUTDIR/"kraken2/{sample}.mpa_style.txt"), sample=SAMPLES),
+        txt=expand(str(OUTDIR/"kraken2/{sample}.mpa_style.txt"), sample=SAMPLES),
     output:
         table=report(OUTDIR/"kraken2/all_samples.mpa_style.txt",
                category="Taxonomic profiling",
@@ -310,7 +310,7 @@ rule bracken_mpa_style:
     input:
         kreport=OUTDIR/"kraken2/{sample}_bracken.kreport"
     output:
-       .txt=OUTDIR/"kraken2/{sample}.bracken.mpa_style.txt",
+        txt=OUTDIR/"kraken2/{sample}.bracken.mpa_style.txt",
     log:
         str(LOGDIR/"kraken2/{sample}.bracken.mpa_style.log")
     threads:
@@ -330,7 +330,7 @@ rule bracken_mpa_style:
 
 rule join_bracken_mpa:
     input:
-       .txt=expand(str(OUTDIR/"kraken2/{sample}.bracken.mpa_style.txt"), sample=SAMPLES),
+        txt=expand(str(OUTDIR/"kraken2/{sample}.bracken.mpa_style.txt"), sample=SAMPLES),
     output:
         table=report(OUTDIR/"kraken2/all_samples.bracken.mpa_style.txt",
                category="Taxonomic profiling",

--- a/rules/taxonomic_profiling/kraken2.smk
+++ b/rules/taxonomic_profiling/kraken2.smk
@@ -36,9 +36,9 @@ if config["taxonomic_profile"]["kraken2"]:
     # SAMPLES is also from the main Snakefile scope.
     krakens = expand(str(OUTDIR/"kraken2/{sample}.kraken"), sample=SAMPLES)
     kreports = expand(str(OUTDIR/"kraken2/{sample}.kreport"), sample=SAMPLES)
-    kreports_mpa_style = expand(str(OUTDIR/"kraken2/{sample}.mpa_style.tsv"), sample=SAMPLES)
-    joined_kreport_mpa_style = str(OUTDIR/"kraken2/all_samples.mpa_style.tsv")
-    combined_kreport = str(OUTDIR/"kraken2/all_samples.kraken2.tsv")
+    kreports_mpa_style = expand(str(OUTDIR/"kraken2/{sample}.mpa_style.txt"), sample=SAMPLES)
+    joined_kreport_mpa_style = str(OUTDIR/"kraken2/all_samples.mpa_style.txt")
+    combined_kreport = str(OUTDIR/"kraken2/all_samples.kraken2.txt")
     kraken_krona = str(OUTDIR/"kraken2/all_samples.kraken2.krona.html")
     all_outputs.extend(krakens)
     all_outputs.extend(kreports)
@@ -110,7 +110,7 @@ rule kraken_mpa_style:
     input:
         kreport=OUTDIR/"kraken2/{sample}.kreport"
     output:
-        tsv=OUTDIR/"kraken2/{sample}.mpa_style.tsv",
+       .txt=OUTDIR/"kraken2/{sample}.mpa_style.txt",
     log:
         str(LOGDIR/"kraken2/{sample}.mpa_style.log")
     threads:
@@ -121,18 +121,18 @@ rule kraken_mpa_style:
         """
         kreport2mpa.py \
             --report-file {input.kreport} \
-            --output {output.tsv} \
+            --output {output.txt} \
             --display-header \
             2>&1 > {log}
-        sed --in-place 's|{input.kreport}|taxon_name\treads|g' {output.tsv}
+        sed --in-place 's|{input.kreport}|taxon_name\treads|g' {output.txt}
         """
 
 
 rule join_kraken2_mpa:
     input:
-        tsv=expand(str(OUTDIR/"kraken2/{sample}.mpa_style.tsv"), sample=SAMPLES),
+       .txt=expand(str(OUTDIR/"kraken2/{sample}.mpa_style.txt"), sample=SAMPLES),
     output:
-        table=report(OUTDIR/"kraken2/all_samples.mpa_style.tsv",
+        table=report(OUTDIR/"kraken2/all_samples.mpa_style.txt",
                category="Taxonomic profiling",
                caption="../../report/kraken2_table_mpa.rst"),
     log:
@@ -150,7 +150,7 @@ rule join_kraken2_mpa:
             --outfile {output.table} \
             --value-column {params.value_column} \
             --feature-column {params.feature_column} \
-            {input.tsv} \
+            {input.txt} \
             2>&1 > {log}
         """
 
@@ -158,7 +158,7 @@ rule combine_kreports:
     input:
         kreports=expand(str(OUTDIR/"kraken2/{sample}.kreport"), sample=SAMPLES),
     output:
-        report(OUTDIR/"kraken2/all_samples.kraken2.tsv",
+        report(OUTDIR/"kraken2/all_samples.kraken2.txt",
                category="Taxonomic profiling",
                caption="../../report/kraken2_table.rst"),
     log:
@@ -227,8 +227,8 @@ if config["taxonomic_profile"]["kraken2"] and kraken2_config["bracken"]["kmer_di
         raise WorkflowError(err_message)
     if kraken2_config["filter_bracken"]["include"] or kraken2_config["filter_bracken"]["exclude"]:
         filtered_brackens = expand(str(OUTDIR/"kraken2/{sample}.{level}.filtered.bracken"), sample=SAMPLES, level=kraken2_config["bracken"]["levels"].split())
-        all_table = expand(str(OUTDIR/"kraken2/all_samples.{level}.bracken.tsv"), level=kraken2_config["bracken"]["levels"].split())
-        all_table_filtered = expand(str(OUTDIR/"kraken2/all_samples.{level}.filtered.bracken.tsv"), level=kraken2_config["bracken"]["levels"].split())
+        all_table = expand(str(OUTDIR/"kraken2/all_samples.{level}.bracken.txt"), level=kraken2_config["bracken"]["levels"].split())
+        all_table_filtered = expand(str(OUTDIR/"kraken2/all_samples.{level}.filtered.bracken.txt"), level=kraken2_config["bracken"]["levels"].split())
 
         all_outputs.extend(filtered_brackens)
         all_outputs.append(all_table)
@@ -237,9 +237,9 @@ if config["taxonomic_profile"]["kraken2"] and kraken2_config["bracken"]["kmer_di
     citations.add(publications["Bracken"])
 
     brackens = expand(str(OUTDIR/"kraken2/{sample}.{level}.bracken"), sample=SAMPLES, level=kraken2_config["bracken"]["levels"].split())
-    brackens_mpa_style = expand(str(OUTDIR/"kraken2/{sample}.bracken.mpa_style.tsv"), sample=SAMPLES)
+    brackens_mpa_style = expand(str(OUTDIR/"kraken2/{sample}.bracken.mpa_style.txt"), sample=SAMPLES)
     bracken_krona = str(OUTDIR/"kraken2/all_samples.bracken.krona.html")
-    all_table_mpa = str(OUTDIR/"kraken2/all_samples.bracken.mpa_style.tsv")
+    all_table_mpa = str(OUTDIR/"kraken2/all_samples.bracken.mpa_style.txt")
 
     all_outputs.extend(brackens)
     all_outputs.extend(brackens_mpa_style)
@@ -310,7 +310,7 @@ rule bracken_mpa_style:
     input:
         kreport=OUTDIR/"kraken2/{sample}_bracken.kreport"
     output:
-        tsv=OUTDIR/"kraken2/{sample}.bracken.mpa_style.tsv",
+       .txt=OUTDIR/"kraken2/{sample}.bracken.mpa_style.txt",
     log:
         str(LOGDIR/"kraken2/{sample}.bracken.mpa_style.log")
     threads:
@@ -321,18 +321,18 @@ rule bracken_mpa_style:
         """
         kreport2mpa.py \
             --report-file {input.kreport} \
-            --output {output.tsv} \
+            --output {output.txt} \
             --display-header \
             2>&1 > {log}
-        sed --in-place 's|{input.kreport}|taxon_name\treads|g' {output.tsv}
+        sed --in-place 's|{input.kreport}|taxon_name\treads|g' {output.txt}
         """
 
 
 rule join_bracken_mpa:
     input:
-        tsv=expand(str(OUTDIR/"kraken2/{sample}.bracken.mpa_style.tsv"), sample=SAMPLES),
+       .txt=expand(str(OUTDIR/"kraken2/{sample}.bracken.mpa_style.txt"), sample=SAMPLES),
     output:
-        table=report(OUTDIR/"kraken2/all_samples.bracken.mpa_style.tsv",
+        table=report(OUTDIR/"kraken2/all_samples.bracken.mpa_style.txt",
                category="Taxonomic profiling",
                caption="../../report/bracken_table_mpa.rst"),
     log:
@@ -350,7 +350,7 @@ rule join_bracken_mpa:
             --outfile {output.table} \
             --value-column {params.value_column} \
             --feature-column {params.feature_column} \
-            {input.tsv} \
+            {input.txt} \
             2>&1 > {log}
         """
 
@@ -359,7 +359,7 @@ rule join_bracken:
     input:
         bracken=expand(str(OUTDIR/"kraken2/{sample}.{{level}}.bracken"), sample=SAMPLES),
     output:
-        table=report(OUTDIR/"kraken2/all_samples.{level,[DPOCFGS]}.bracken.tsv",
+        table=report(OUTDIR/"kraken2/all_samples.{level,[DPOCFGS]}.bracken.txt",
                category="Taxonomic profiling",
                caption="../../report/bracken_table.rst"),
     log:
@@ -453,7 +453,7 @@ rule join_bracken_filtered:
     input:
         bracken=expand(str(OUTDIR/"kraken2/{sample}.{{level}}.filtered.bracken"), sample=SAMPLES),
     output:
-        table=report(OUTDIR/"kraken2/all_samples.{level,[DPCOFGS]}.filtered.bracken.tsv",
+        table=report(OUTDIR/"kraken2/all_samples.{level,[DPCOFGS]}.filtered.bracken.txt",
                category="Taxonomic profiling",
                caption="../../report/bracken_table.rst"),
     log:


### PR DESCRIPTION
Change all tsv outputs to txt so the tables don't get made into pretty HTML tables that screw up their formatting. If Snakemake even makes tsv to html conversion optional in the future we might change it back, because I prefer the .tsv extension over .txt. 