### PR TITLE
Disable Bracken in CTMR automation branch

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -104,7 +104,7 @@ kraken2:
     confidence: 0.1          # Kraken2 confidence score, float in [0,1]
     extra: ""                # Extra command line arguments for kraken2 (do not add/change output files)
     bracken:
-        kmer_distrib: "/db/kraken2/ctmr_abvhf/database150mers.kmer_distrib"     # [Required for Bracken] Path to kmer_distrib file for Kraken2 DB specified above
+        kmer_distrib: ""     # [Required for Bracken] Path to kmer_distrib file for Kraken2 DB specified above
         levels: "S G F"        # Space-separated list of taxonomic levels to produce tables for (e.g. "F G S" for Family, Genus, Species)
         thresh: 10           # Threshold for minimum number of reads from Kraken
     filter_bracken:          # Arguments to filter_bracken_out.py to include/exclude certain taxa


### PR DESCRIPTION
Bracken continuously creates issues with the automation with scripts failing due to different reasons, incomplete files, etc.