### PR TITLE
Slurm profile for CTMR UCP environment

### DIFF
--- a/cluster_configs/ctmr_ucp/config.yaml
+++ b/cluster_configs/ctmr_ucp/config.yaml
@@ -1,5 +1,5 @@
 jobscript: "cluster_configs/ctmr_ucp/slurm-jobscript.sh"
-cluster: "cluster_configs/ctmr_ucp/slurm-submit.py --cpus-per-task {cluster.n} --time {cluster.time} --error {cluster.stderr} --output {cluster.stdout} --job-name '{cluster.jobname}' {cluster.extra}"
+cluster: "cluster_configs/ctmr_ucp/slurm-submit.py --time {cluster.time} --error {cluster.stderr} --output {cluster.stdout} --job-name '{cluster.jobname}' {cluster.extra}"
 cluster-status: "cluster_configs/ctmr_ucp/slurm-status.py"
 cluster-config: "cluster_configs/ctmr_ucp/ctmr_ucp.yaml"
 max-jobs-per-second: 10

--- a/cluster_configs/ctmr_ucp/config.yaml
+++ b/cluster_configs/ctmr_ucp/config.yaml
@@ -1,0 +1,8 @@
+jobscript: "cluster_configs/rackham/slurm-jobscript.sh"
+cluster: "cluster_configs/rackham/slurm-submit.py --cpus-per-task {cluster.n} --time {cluster.time} --error {cluster.stderr} --output {cluster.stdout} --job-name '{cluster.jobname}' {cluster.extra}"
+cluster-status: "cluster_configs/rackham/slurm-status.py"
+cluster-config: "cluster_configs/rackham/rackham.yaml"
+max-jobs-per-second: 10
+max-status-checks-per-second: 10
+local-cores: 1
+jobs: 999

--- a/cluster_configs/ctmr_ucp/ctmr_ucp.yaml
+++ b/cluster_configs/ctmr_ucp/ctmr_ucp.yaml
@@ -1,0 +1,90 @@
+# Cluster config file for StaG-mwc for use on CTMR UCP
+__default__:
+    account: ""
+    partition: ""
+    extra: ""
+    time: "03:00:00"
+    n: 2
+    stderr: "slurm_logs/slurm-{rule}-{wildcards}.stderr"
+    stdout: "slurm_logs/slurm-{rule}-{wildcards}.stdout"
+    jobname: "[{rule}]: {wildcards}"
+
+
+#############################
+# Pre-processing
+#############################
+fastp:
+    n: 4
+    time: "01:00:00"
+remove_host:
+    n: 4
+    time: "01:00:00"
+bbcountunique:
+    n: 2
+    time: "00:45:00"
+
+#############################
+# Naive comparisons
+#############################
+sketch:
+    n: 2
+    time: "00:20:00"
+
+#############################
+# Taxonomic profiling
+#############################
+kaiju:
+    n: 8
+    time: "02:00:00"
+kraken2:
+    n: 8
+    time: "02:00:00"
+metaphlan2:
+    n: 8
+    time: "01:30:00"
+bracken:
+    n: 2
+    time: "01:00:00"
+
+#############################
+# Functional profiling
+#############################
+humann2:
+    n: 8
+    time: "12:00:00"
+
+#############################
+# Antibiotic resistance
+#############################
+groot_align:
+    n: 6
+    time: "01:00:00"
+align_to_amr:
+    n: 10
+    time: "04:00:00"
+
+#############################
+# Mappers
+#############################
+bbmap:
+    n: 8
+    time: "02:00:00"
+bowtie2:
+    n: 8
+    time: "02:00:00"
+
+#############################
+# Assembly
+#############################
+assembly:
+    n: 20
+    time: "05:00:00"
+assembly:
+    n: 20
+    time: "05:00:00"
+consolidate_bins:
+    n: 20
+    time: "05:00:00"
+blobology:
+    n: 20
+    time: "05:00:00"

--- a/cluster_configs/ctmr_ucp/ctmr_ucp.yaml
+++ b/cluster_configs/ctmr_ucp/ctmr_ucp.yaml
@@ -1,7 +1,7 @@
 # Cluster config file for StaG-mwc for use on CTMR UCP
 __default__:
-    account: ""
-    partition: ""
+    account: "bio"
+    partition: "ctmr"
     extra: ""
     time: "03:00:00"
     n: 2

--- a/cluster_configs/ctmr_ucp/ctmr_ucp.yaml
+++ b/cluster_configs/ctmr_ucp/ctmr_ucp.yaml
@@ -14,30 +14,30 @@ __default__:
 # Pre-processing
 #############################
 fastp:
-    n: 4
+    n: 8
     time: "01:00:00"
 remove_host:
-    n: 4
+    n: 8
     time: "01:00:00"
 bbcountunique:
-    n: 2
+    n: 4
     time: "00:45:00"
 
 #############################
 # Naive comparisons
 #############################
 sketch:
-    n: 2
+    n: 8
     time: "00:20:00"
 
 #############################
 # Taxonomic profiling
 #############################
 kaiju:
-    n: 8
+    n: 10
     time: "02:00:00"
 kraken2:
-    n: 8
+    n: 10
     time: "02:00:00"
 metaphlan2:
     n: 8
@@ -50,14 +50,14 @@ bracken:
 # Functional profiling
 #############################
 humann2:
-    n: 8
+    n: 12
     time: "12:00:00"
 
 #############################
 # Antibiotic resistance
 #############################
 groot_align:
-    n: 6
+    n: 8
     time: "01:00:00"
 align_to_amr:
     n: 10
@@ -67,10 +67,10 @@ align_to_amr:
 # Mappers
 #############################
 bbmap:
-    n: 8
+    n: 10
     time: "02:00:00"
 bowtie2:
-    n: 8
+    n: 10
     time: "02:00:00"
 
 #############################

--- a/cluster_configs/ctmr_ucp/slurm-jobscript.sh
+++ b/cluster_configs/ctmr_ucp/slurm-jobscript.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# properties = {properties}
+{exec_job}

--- a/cluster_configs/ctmr_ucp/slurm-status.py
+++ b/cluster_configs/ctmr_ucp/slurm-status.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import re
+import subprocess as sp
+import shlex
+import sys
+import time
+import logging
+logger = logging.getLogger("__name__")
+
+STATUS_ATTEMPTS = 20
+
+jobid = sys.argv[1]
+
+for i in range(STATUS_ATTEMPTS):
+    try:
+        sacct_res = sp.check_output(shlex.split("sacct -P -b -j {} -n".format(jobid)))
+        res = {x.split("|")[0]: x.split("|")[1] for x in sacct_res.decode().strip().split("\n")}
+        break
+    except sp.CalledProcessError as e:
+        logger.error("sacct process error")
+        logger.error(e)
+    except IndexError as e:
+        pass
+    # Try getting job with scontrol instead in case sacct is misconfigured
+    try:
+        sctrl_res = sp.check_output(shlex.split("scontrol -o show job {}".format(jobid)))
+        m = re.search("JobState=(\w+)", sctrl_res.decode())
+        res = {jobid: m.group(1)}
+        break
+    except sp.CalledProcessError as e:
+        logger.error("scontrol process error")
+        logger.error(e)
+        if i >= STATUS_ATTEMPTS - 1:
+            print("failed")
+            exit(0)
+        else:
+            time.sleep(1)
+
+status = res[jobid]
+
+if (status.startswith("BOOT_FAIL")):
+    print("failed")
+elif (status.startswith("CANCELLED")):
+    print("failed")
+elif (status.startswith("COMPLETED")):
+    print("success")
+elif (status.startswith("DEADLINE")):
+    print("failed")
+elif (status.startswith("FAILED")):
+    print("failed")
+elif (status.startswith("NODE_FAIL")):
+    print("failed")
+elif (status.startswith("PREEMPTED")):
+    print("failed")
+elif (status.startswith("TIMEOUT")):
+    print("failed")
+# Unclear whether SUSPENDED should be treated as running or failed
+elif (status.startswith("SUSPENDED")):
+    print("failed")
+else:
+    print("running")

--- a/cluster_configs/ctmr_ucp/slurm-submit.py
+++ b/cluster_configs/ctmr_ucp/slurm-submit.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+import sys
+import re
+import argparse
+import subprocess
+from pathlib import Path
+
+from snakemake.utils import read_job_properties
+
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument(
+    "--help", help="Display help message.", action="store_true")
+parser.add_argument(
+    "positional", action="append",
+    nargs="?", metavar="POS",
+    help="additional arguments not in slurm parser group to pass to sbatch")
+
+# A subset of SLURM-specific arguments
+slurm_parser = parser.add_argument_group("slurm-specific arguments")
+slurm_parser.add_argument(
+    "-a", "--array", help="job array index values")
+slurm_parser.add_argument(
+    "-A", "--account", help="charge job to specified account")
+slurm_parser.add_argument(
+    "--begin", help="defer job until HH:MM MM/DD/YY")
+slurm_parser.add_argument(
+    "-c", "--cpus-per-task", help="number of cpus required per task")
+slurm_parser.add_argument(
+    "-d", "--dependency",
+    help="defer job until condition on jobid is satisfied")
+slurm_parser.add_argument(
+    "-D", "--workdir", help="set working directory for batch script")
+slurm_parser.add_argument(
+    "-e", "--error", help="file for batch script's standard error")
+slurm_parser.add_argument(
+    "-J", "--job-name", help="name of job")
+slurm_parser.add_argument(
+    "--mail-type", help="notify on state change: BEGIN, END, FAIL or ALL")
+slurm_parser.add_argument(
+    "--mail-user", help="who to send email notification for job state changes")
+slurm_parser.add_argument(
+    "-n", "--ntasks", help="number of tasks to run")
+slurm_parser.add_argument(
+    "-N", "--nodes", help="number of nodes on which to run (N = min[-max])")
+slurm_parser.add_argument(
+    "-o", "--output", help="file for batch script's standard output")
+slurm_parser.add_argument(
+    "-p", "--partition", help="partition requested")
+slurm_parser.add_argument(
+    "-q", "--qos", help="quality of service")
+slurm_parser.add_argument(
+    "-Q", "--quiet", help="quiet mode (suppress informational messages)")
+slurm_parser.add_argument(
+    "-t", "--time", help="time limit")
+slurm_parser.add_argument(
+    "--wrap", help="wrap command string in a sh script and submit")
+slurm_parser.add_argument(
+    "-C", "--constraint", help="specify a list of constraints")
+slurm_parser.add_argument(
+    "--mem", help="minimum amount of real memory")
+
+args = parser.parse_args()
+
+if args.help:
+    parser.print_help()
+    sys.exit(0)
+
+jobscript = sys.argv[-1]
+job_properties = read_job_properties(jobscript)
+
+extras = ""
+if args.positional:
+    for m in args.positional:
+        if m is not None:
+            extras = extras + " " + m
+
+arg_dict = dict(args.__dict__)
+
+
+# Process resources
+if "resources" in job_properties:
+    resources = job_properties["resources"]
+    if arg_dict["time"] is None:
+        if "runtime" in resources:
+            arg_dict["time"] = resources["runtime"]
+        elif "walltime" in resources:
+            arg_dict["time"] = resources["walltime"]
+    if "mem" in resources and arg_dict["mem"] is None:
+        arg_dict["mem"] = resources["mem"]
+
+# Threads
+if "threads" in job_properties:
+    arg_dict["ntasks"] = job_properties["threads"]
+
+opt_keys = {"array", "account", "begin", "cpus_per_task",
+            "depedency", "workdir", "error", "job_name", "mail_type",
+            "mail_user", "ntasks", "nodes", "output", "partition",
+            "quiet", "time", "wrap", "constraint", "mem"}
+
+# Set default partition
+if arg_dict["partition"] is None:
+    if not "core":
+        # partitions and SLURM - If not specified, the default behavior is to
+        # allow the slurm controller to select the default partition as
+        # designated by the system administrator.
+        opt_keys.remove("partition")
+    else:
+        arg_dict["partition"] = "core"
+
+# Set default account
+if arg_dict["account"] is None:
+    raise Exception("Cannot submit Slurm jobs without account!")
+
+# Ensure output folder for Slurm log files exist
+# This is a bit hacky; it will try to create the folder
+# for every Slurm submission...
+if "output" in arg_dict:
+    stdout_folder = Path(arg_dict["output"]).parent
+    stdout_folder.mkdir(exist_ok=True, parents=True)
+if "error" in arg_dict:
+    stdout_folder = Path(arg_dict["error"]).parent
+    stdout_folder.mkdir(exist_ok=True, parents=True)
+
+opts = ""
+for k, v in arg_dict.items():
+    if k not in opt_keys:
+        continue
+    if v is not None:
+        opts += " --{} \"{}\" ".format(k.replace("_", "-"), v)
+
+if arg_dict["wrap"] is not None:
+    cmd = "sbatch {opts}".format(opts=opts)
+else:
+    cmd = "sbatch {opts} {extras}".format(opts=opts, extras=extras)
+
+try:
+    res = subprocess.run(cmd, check=True, shell=True, stdout=subprocess.PIPE)
+except subprocess.CalledProcessError as e:
+    raise e
+
+# Get jobid
+res = res.stdout.decode()
+try:
+    m = re.search("Submitted batch job (\d+)", res)
+    jobid = m.group(1)
+    print(jobid)
+except Exception as e:
+    print(e)
+    raise


### PR DESCRIPTION
The CTMR UCP Slurm environment is a bit special, we have no accounts and all people currently use the same (default) partition `ctmr`. 

Currently, using the profile throws continuous error messages like 
```
sacct process error                                                                
Command '['sacct', '-P', '-b', '-j', '924', '-n']' returned non-zero exit status 1.
Slurm accounting storage is disabled                                               
```
because we haven't implemented Slurm accounts and accounting yet. It still runs, however.
