### PR TITLE
Change report generation call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ situations.
 - All rules now define the number of threads from cluster_config if defined.
   Old defaults are still used for local execution.
 - The shebang of `area_plot.py` has been changed to work in more environments.
+- Implemented workaround for error caused by automatic report generation when using Singularity
 
 ### Removed
 

--- a/Snakefile
+++ b/Snakefile
@@ -154,8 +154,8 @@ onsuccess:
         Path("citations.rst").symlink_to(citation_filename)
 
         snakemake_call = " ".join(argv)
-        shell("{snakemake_call} --unlock".format(snakemake_call=snakemake_call))
-        shell("{snakemake_call} --report {report}-{datetime}.html".format(
+        shell("{snakemake_call[0]} --unlock".format(snakemake_call=snakemake_call))
+        shell("{snakemake_call[0]} --report {report}-{datetime}.html".format(
             snakemake_call=snakemake_call,
             report=config["report"],
             datetime=report_datetime,

--- a/Snakefile
+++ b/Snakefile
@@ -153,10 +153,8 @@ onsuccess:
             Path("citations.rst").unlink()
         Path("citations.rst").symlink_to(citation_filename)
 
-        snakemake_call = " ".join(argv)
-        shell("{snakemake_call[0]} --unlock".format(snakemake_call=snakemake_call))
-        shell("{snakemake_call[0]} --report {report}-{datetime}.html".format(
-            snakemake_call=snakemake_call,
+        shell("snakemake --unlock")
+        shell("snakemake --report {report}-{datetime}.html".format(
             report=config["report"],
             datetime=report_datetime,
             )

--- a/Snakefile
+++ b/Snakefile
@@ -155,7 +155,7 @@ onsuccess:
 
         shell("{snakemake_call} --unlock".format(snakemake_call=argv[0]))
         shell("{snakemake_call} --report {report}-{datetime}.html".format(
-                snakemake_call=argv[0],
+            snakemake_call=argv[0],
             report=config["report"],
             datetime=report_datetime,
             )

--- a/Snakefile
+++ b/Snakefile
@@ -153,7 +153,7 @@ onsuccess:
             Path("citations.rst").unlink()
         Path("citations.rst").symlink_to(citation_filename)
 
-        shell("snakemake --unlock")
+        shell("{snakemake_call} --unlock".format(snakemake_call=argv[0]))
         shell("{snakemake_call} --report {report}-{datetime}.html".format(
                 snakemake_call=argv[0],
             report=config["report"],

--- a/Snakefile
+++ b/Snakefile
@@ -154,9 +154,9 @@ onsuccess:
         Path("citations.rst").symlink_to(citation_filename)
 
         shell("snakemake --unlock")
-        shell("snakemake --report {report}-{datetime}.html".format(
+        shell("{snakemake_call} --report {report}-{datetime}.html".format(
+                snakemake_call=argv[0],
             report=config["report"],
             datetime=report_datetime,
             )
         )
-


### PR DESCRIPTION
Ignore additional arguments to snakemake when creating report,

Intended to avoid shell escaping issue with complex arguments to e.g. Singularity, issue #160