### PR TITLE
Update Snakefile

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -182,4 +182,4 @@ onsuccess:
             snakemake_call=argv[0],
             report=config["report"],
             datetime=report_datetime,
-            ))
+        ))

--- a/Snakefile
+++ b/Snakefile
@@ -177,5 +177,9 @@ onsuccess:
             snakemake_call=argv[0],
             report=config["report"],
             datetime=report_datetime,
-            )
-        )
+            ))
+        shell("{snakemake_call} --report {report}-{datetime}.zip".format(
+            snakemake_call=argv[0],
+            report=config["report"],
+            datetime=report_datetime,
+            ))

--- a/Snakefile
+++ b/Snakefile
@@ -177,7 +177,7 @@ onsuccess:
             snakemake_call=argv[0],
             report=config["report"],
             datetime=report_datetime,
-            ))
+        ))
         shell("{snakemake_call} --report {report}-{datetime}.zip".format(
             snakemake_call=argv[0],
             report=config["report"],


### PR DESCRIPTION
HMTL embedded files could not be opened from the browser any longer. Creating an additional zip-report circumvents the issue.