### PR TITLE
Add samplesheet input option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ situations.
 ### Added
 - Produce Snakemake report in zip format as well as HTML due to the HTML report being
   broken in the later versions of Snakemake.
+- Added samplesheet as alternative input file selection method.
 
 ### Fixed
 - Corrected typo in `host_removal` rule concerning `keep_kreport` config flag.

--- a/Snakefile
+++ b/Snakefile
@@ -54,9 +54,12 @@ onstart:
     )
 
     if len(SAMPLES) < 1:
-        raise WorkflowError("Found no samples! Check input file pattern and path in config.yaml")
+        raise WorkflowError("Found no samples! Check input file options in config.yaml")
     else:
-        print(f"Found the following samples in inputdir using input filename pattern '{config['input_fn_pattern']}':\n{SAMPLES}")
+        if config["samplesheet"]:
+            print(f"Found these samples in '{config['samplesheet']}':\n{SAMPLES}")
+        else:
+            print(f"Found these samples in '{config['inputdir']}' using input filename pattern '{config['input_fn_pattern']}':\n{SAMPLES}")
 
 
 #############################

--- a/Snakefile
+++ b/Snakefile
@@ -15,7 +15,7 @@ from snakemake.utils import min_version
 min_version("5.5.4")
 
 from rules.publications import publications
-from scripts.common import UserMessages
+from scripts.common import UserMessages, SampleSheet
 
 user_messages = UserMessages()
 
@@ -33,7 +33,15 @@ TMPDIR = Path(config["tmpdir"])
 DBDIR = Path(config["dbdir"])
 all_outputs = []
 
-SAMPLES = set(glob_wildcards(INPUTDIR/config["input_fn_pattern"]).sample)
+if config["samplesheet"]:
+    samplesheet = SampleSheet(config["samplesheet"], endpoint_url=config["s3_endpoint_url"])
+    SAMPLES = samplesheet.samples
+    INPUT_read1 = lambda w: samplesheet.sample_info[w.sample]["read1"]
+    INPUT_read2 = lambda w: samplesheet.sample_info[w.sample]["read2"]
+else:
+    SAMPLES = set(glob_wildcards(INPUTDIR/config["input_fn_pattern"]).sample)
+    INPUT_read1 = INPUTDIR/config["input_fn_pattern"].format(sample="{sample}", readpair="1"),
+    INPUT_read2 = INPUTDIR/config["input_fn_pattern"].format(sample="{sample}", readpair="2")
 
 onstart:
     print("\n".join([

--- a/Snakefile
+++ b/Snakefile
@@ -34,7 +34,7 @@ DBDIR = Path(config["dbdir"])
 all_outputs = []
 
 if config["samplesheet"]:
-    samplesheet = SampleSheet(config["samplesheet"], endpoint_url=config["s3_endpoint_url"])
+    samplesheet = SampleSheet(config["samplesheet"], keep_local=config["keep_local"], endpoint_url=config["s3_endpoint_url"])
     SAMPLES = samplesheet.samples
     INPUT_read1 = lambda w: samplesheet.sample_info[w.sample]["read1"]
     INPUT_read2 = lambda w: samplesheet.sample_info[w.sample]["read2"]

--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,7 @@ email: ""                 # Email to send status message after completed/failed 
 # Remote services
 #########################
 s3_endpoint_url: "https://s3.ki.se"  # Use https://s3.amazonaws.com for Amazon S3
+keep_local: False                    # Keep local copies of remote input files, default False.
 
 
 #########################

--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,12 @@ tmpdir: "/tmp"            # Specifying a tmpdir is not normally necessary but so
 dbdir: "databases"        # Databases will be downloaded to this dir, if requested
 report: "StaG_report-"    # Filename prefix for report file ("-{datetime}.html" automatically appended)
 email: ""                 # Email to send status message after completed/failed run.
-s3_endpoint_url: "https://s3.ki.se"
+
+
+#########################
+# Remote services
+#########################
+s3_endpoint_url: "https://s3.ki.se"  # Use https://s3.amazonaws.com for Amazon S3
 
 
 #########################
@@ -37,9 +42,9 @@ taxonomic_profile:
     kraken2: False
     metaphlan: False
 strain_level_profiling:
-    strainphlan: False        # Will also run metaphlan. Please make sure you've added bt2_db_dir and bt2_index under metaphlan settings.
+    strainphlan: False    # Will also run metaphlan. Please make sure you've added bt2_db_dir and bt2_index under metaphlan settings.
 functional_profile:
-    humann: False
+    humann: False         # Will also run metaphlan. Please make sure you've added bt2_db_dir and bt2_index under metaphlan settings.
 antibiotic_resistance:
     groot: False
     amrplusplus: False
@@ -58,7 +63,7 @@ fastp:
     extra: ""
     keep_output: False       # StaG deletes fastp output files after host removal, set to True to keep them.
 remove_host:
-    db_path: "/ceph/db/kraken2/kraken2_GRCh38"              # [Required] Path to folder containing a Kraken2 database with host sequences (taxo.k2d, etc.)
+    db_path: ""              # [Required] Path to folder containing a Kraken2 database with host sequences (taxo.k2d, etc.)
     confidence: 0.1          # Kraken2 confidence parameter, normally set to 0.1
     extra: "--quick"         # Additional command line arguments to kraken2
     keep_kraken: False       # StaG deletes the kraken and kreport output files by default, set to True to keep them.
@@ -196,3 +201,4 @@ metawrap:
     universal: "--universal"  # Use universal marker genes
     minimum_completion: 70
     maximum_contamination: 10
+

--- a/config.yaml
+++ b/config.yaml
@@ -14,12 +14,14 @@
 #########################
 inputdir: "input"
 input_fn_pattern: "{sample}_{readpair}.fq.gz"
+samplesheet: ""           # Three-column samplesheet with sample_id,fastq_1,fastq_2 columns. Used instead of inputdir
 outdir: "output_dir"
 logdir: "output_dir/logs"
 tmpdir: "/tmp"            # Specifying a tmpdir is not normally necessary but some tools like HUMAnN requires it. If required please enter path to a temp directory e.g. /scratch
 dbdir: "databases"        # Databases will be downloaded to this dir, if requested
 report: "StaG_report-"    # Filename prefix for report file ("-{datetime}.html" automatically appended)
 email: ""                 # Email to send status message after completed/failed run.
+s3_endpoint_url: "https://s3.ki.se"
 
 
 #########################
@@ -56,7 +58,7 @@ fastp:
     extra: ""
     keep_output: False       # StaG deletes fastp output files after host removal, set to True to keep them.
 remove_host:
-    db_path: ""              # [Required] Path to folder containing a Kraken2 database with host sequences (taxo.k2d, etc.)
+    db_path: "/ceph/db/kraken2/kraken2_GRCh38"              # [Required] Path to folder containing a Kraken2 database with host sequences (taxo.k2d, etc.)
     confidence: 0.1          # Kraken2 confidence parameter, normally set to 0.1
     extra: "--quick"         # Additional command line arguments to kraken2
     keep_kraken: False       # StaG deletes the kraken and kreport output files by default, set to True to keep them.

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -4,13 +4,55 @@ You need to configure a workflow before you can run |full_name|. The code
 you downloaded in the previous ``git clone`` step includes a file called 
 ``config.yaml``, which is used to configure the workflow. 
 
-Open ``config.yaml`` in your favorite editor and change the settings under the
-``Run configuration`` heading: the input directory, the input filename pattern,
-and the output directory, are the most important ones. They can be declared
-using absolute or relative filenames (relative to the |full_name| repository
-directory). Input and output directories can be located anywhere, i.e. their
-locations are not restricted to the repository folder.
+Selecting input files
+*********************
+There are two ways to define which files |full_name| should run on: either
+by specifying an input directory and a filename pattern, or by providing
+a sample sheet. The two ways are exclusive and cannot be combined, so you have
+to pick the one that suits you best. 
 
+Input directory
+---------------
+If your input FASTQ files are all in the same folder and they all follow the
+same filename pattern, the input directory option is often the most convenient.
+
+Open ``config.yaml`` in your favorite editor and change input file settings
+under the ``Run configuration`` heading: the input directory, the input
+filename pattern. They can be declared using absolute or relative filenames
+(relative to the |full_name| repository directory). Input and output
+directories can technically be located anywhere, i.e. their locations are not
+restricted to the repository folder, but it is recommended to keep them in the
+repository directory. A common practice is to put symlinks to the files you
+want to analyze in a folder called ``input`` in the repository folder.
+
+Samplesheet
+-----------
+If your input FASTQ files are spread across several filesystem locations or
+potentially exist in remote locations (e.g. S3), or your input FASTQ filenames
+do not follow a common filename pattern, the samplesheet option is the most
+convenient. The samplesheet input option also allows you to specify custom
+sample names that are not derived from a substring of the input filenames.
+
+The format of the samplesheet is tab-separated text and it must contain a
+header line with at least the following three columns: ``sample_id``,
+``fastq_1``, and ``fastq_2``. An example file could look like this (columns are
+separated by TAB characters)::
+
+   sample_id  fastq_1                           fastq_2
+   ABC123     /path/to/sample1_1.fq.gz          /path/to/sample1_2.fq.gz
+   DEF456     s3://bucketname/sample_R1.fq.gz   s3://bucketname/sample_R2.fq.gz
+
+Open ``config.yaml`` in your favorite editor and enter the path to a
+samplesheet TSV file that you have prepared in advance in the ``samplesheet``
+filed under the ``Run configuration`` heading: They paths can be declared using
+absolute or relative filenames (relative to the |full_name| repository
+directory). Input files can be located anywhere, i.e. their locations are not
+restricted to the repository folder and they can even be located in remote
+storage systems like S3.
+
+
+Configuring which tools to run
+******************************
 Next, configure the settings under the ``Pipeline steps included`` heading.
 This is where you define what steps should be included in your workflow. Simply
 assign ``True`` or ``False`` to the steps you want to include. Note that the

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -50,6 +50,12 @@ directory). Input files can be located anywhere, i.e. their locations are not
 restricted to the repository folder and they can even be located in remote
 storage systems like S3.
 
+.. note::
+
+   When the path to a samplesheet TSV file has been specified in the config
+   file |full_name| will ignore the ``inputdir`` and ``input_fn_pattern``
+   settings.
+
 
 Configuring which tools to run
 ******************************

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -56,6 +56,9 @@ storage systems like S3.
    file |full_name| will ignore the ``inputdir`` and ``input_fn_pattern``
    settings.
 
+It is possible to keep a local copy of remote input files in the repository
+folder after the run by setting ``keep_local: True`` in the config file.
+
 
 Configuring which tools to run
 ******************************

--- a/rules/naive/bbcountunique.smk
+++ b/rules/naive/bbcountunique.smk
@@ -15,7 +15,7 @@ if config["naive"]["assess_depth"]:
     rule bbcountunique:
         """Assess sequencing depth using BBCountUnique."""
         input:
-            INPUTDIR/config["input_fn_pattern"].format(sample="{sample}", readpair="1")
+            INPUT_read1,
         output:
             txt=OUTDIR/"bbcountunique/{sample}.bbcountunique.txt",
             pdf=report(OUTDIR/"bbcountunique/{sample}.bbcountunique.pdf",

--- a/rules/naive/sketch_compare.smk
+++ b/rules/naive/sketch_compare.smk
@@ -20,7 +20,7 @@ rule sketch:
     """Create MinHash sketches of samples using BBMap's sketch.sh.
     Uses only the first readpair of each sample."""
     input:
-        INPUTDIR/config["input_fn_pattern"].format(sample="{sample}", readpair="1")
+        INPUT_read1,
     output:
         sketch=OUTDIR/"sketch_compare/{sample}.sketch.gz",
     log:

--- a/rules/preproc/read_quality.smk
+++ b/rules/preproc/read_quality.smk
@@ -18,8 +18,8 @@ if config["qc_reads"]:
 
     rule fastp:
         input:
-            read1=INPUTDIR/config["input_fn_pattern"].format(sample="{sample}", readpair="1"),
-            read2=INPUTDIR/config["input_fn_pattern"].format(sample="{sample}", readpair="2")
+            read1=INPUT_read1,
+            read2=INPUT_read2,
         output:
             read1=OUTDIR/"fastp/{sample}_1.fq.gz" if fastp_config["keep_output"] else temp(OUTDIR/"fastp/{sample}_1.fq.gz"),
             read2=OUTDIR/"fastp/{sample}_2.fq.gz" if fastp_config["keep_output"] else temp(OUTDIR/"fastp/{sample}_2.fq.gz"),
@@ -66,8 +66,8 @@ else:
 
     rule skip_fastp:
         input:
-            read1=INPUTDIR/config["input_fn_pattern"].format(sample="{sample}", readpair="1"),
-            read2=INPUTDIR/config["input_fn_pattern"].format(sample="{sample}", readpair="2")
+            read1=INPUT_read1,
+            read2=INPUT_read2,
         output:
             read1=OUTDIR/"fastp/{sample}_1.fq.gz",
             read2=OUTDIR/"fastp/{sample}_2.fq.gz",

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -44,7 +44,7 @@ class SampleSheet():
     UniqueSampleName1\tinput/sample1_1.fq.gz\tinput/sample1_2.fq.gz
     OtherSample2\ts3://bucket/QWERTY12345_1.fq.gz\ts3://bucket/QWERTY12345_2.fq.gz
     """
-    def __init__(self, samplesheet, endpoint_url="http://s3.amazonaws.com"):
+    def __init__(self, samplesheet, keep_local=False, endpoint_url="http://s3.amazonaws.com"):
         self.sample_info = {}
         self.S3 = S3RemoteProvider(host=endpoint_url)
         self.required_columns = ("sample_id", "fastq_1", "fastq_2")
@@ -62,10 +62,10 @@ class SampleSheet():
 
                 try:
                     if fq1.startswith("s3://"):
-                        fq1 = self.S3.remote(fq1.lstrip("s3://"))
+                        fq1 = self.S3.remote(fq1.lstrip("s3://"), keep_local=keep_local)
                         fq1_source = "S3"
                     if fq2.startswith("s3://"):
-                        fq2 = self.S3.remote(fq2.lstrip("s3://"))
+                        fq2 = self.S3.remote(fq2.lstrip("s3://"), keep_local=keep_local)
                         fq2_source = "S3"
                 except AttributeError as e:
                     raise ValueError(f"Cannot parse line {line} in {samplesheet}")

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -1,4 +1,6 @@
 # This file is part of StaG-mwc
+import csv
+from snakemake.remote.S3 import RemoteProvider as S3RemoteProvider
  
 class UserMessages():
     """
@@ -31,3 +33,39 @@ class UserMessages():
         self.messages["warning"].add(message)
 
         
+class SampleSheet():
+    """Parse three-column samplesheet with header and column names:
+    sample_id -- Unique sample ID 
+    fastq_1   -- (Local/Remote) path to fastq_1
+    fastq_2   -- (Local/Remote) path to fastq_2
+
+    Example:
+    sample_id\tfastq_1\t_fastq_2
+    UniqueSampleName1\tinput/sample1_1.fq.gz\tinput/sample1_2.fq.gz
+    OtherSample2\ts3://bucket/QWERTY12345_1.fq.gz\ts3://bucket/QWERTY12345_2.fq.gz
+    """
+    def __init__(self, samplesheet, endpoint_url="http://s3.amazonaws.com"):
+        self.sample_info = {}
+        self.S3 = S3RemoteProvider(host=endpoint_url)
+
+        with open(samplesheet) as tsvfile:
+            reader = csv.DictReader(tsvfile, delimiter="\t")
+            for row in reader:
+                fq1_source = "local"  # For debugging
+                fq2_source = "local"  # For debugging
+                fq1 = row["fastq_1"]
+                fq2 = row["fastq_2"]
+                if fq1.startswith("s3://"):                   
+                    fq1 = self.S3.remote(fq1.lstrip("s3://"))      
+                    fq1_source = "S3"                         
+                if fq2.startswith("s3://"):                   
+                    fq2 = self.S3.remote(fq2.lstrip("s3://"))      
+                    fq2_source = "S3"                         
+                                                              
+                self.sample_info[row["sample_id"]] = {                 
+                        "read1": fq1, "read1_src": fq1_source,
+                        "read2": fq2, "read2_src": fq2_source,
+                }                                             
+        self.samples = list(self.sample_info.keys())
+
+


### PR DESCRIPTION
Add sample sheet as alternative option to specify input sample names and associated files. Uses a three-column format:
* `sample_id`: unique sample ID
* `fastq_1`: path to FASTQ with forward reads, can be local absolute/relative or S3 paths  e.g. `s3://bucketname/sample1_1.fq.gz`)
* `fastq_2`: path to FASTQ with reverse reads, can be local absolute/relative or S3 paths (e.g. `s3://bucketname/sample1_2.fq.gz`)

Added `samplesheet` config option to config file. If populated, expects TSV samplesheet at given path, which also ignores input dir settings (i.e. it is not possible to combine inputdir and samplesheet right now).

Snakemake makes it possible to dynamically set samplesheet like this:
```
snakemake --cores 4 --config samplesheet=path/to/samplesheet.tsv
```

