### PR TITLE
Make krona optional, change to mpa4 biocontainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ situations.
 ### Added
 - Produce Snakemake report in zip format as well as HTML due to the HTML report being
   broken in the later versions of Snakemake.
+- Added `run_krona` setting for taxonomic profilers to make it possible to disable Krona
+  table and plot creation.
 
 ### Fixed
 - Corrected typo in `host_removal` rule concerning `keep_kreport` config flag.

--- a/config.yaml
+++ b/config.yaml
@@ -84,6 +84,7 @@ kaiju:
     levels: ["species", "genus", "family"]    # Level(s) to summarize Kaiju report to, pick from: superkingdom, phylum, class, order, family, genus, species
     feature_column: "taxon_name"   # Feature column to use in all_samples summary
     value_column: "percent"        # Value column top use in all_samples summary. Options are typically "percent" or "reads"
+    run_krona: True
 
 kraken2:
     db: ""                   # [Required] Path to Kraken2 DB folder
@@ -92,6 +93,7 @@ kraken2:
     extra: ""                # Extra command line arguments for kraken2 (do not add/change output files)
     keep_kraken: False       # Keep the kraken output files
     keep_kreport: True       # Keep the kreport output files
+    run_krona: True
     bracken:
         kmer_distrib: ""     # [Required for Bracken] Path to kmer_distrib file for Kraken2 DB specified above
         levels: "S G"        # Space-separated list of taxonomic levels to produce tables for (e.g. "F G S" for Family, Genus, Species)
@@ -106,6 +108,7 @@ metaphlan:
     extra: ""                # Extra command line arguments for MetaPhlAn e.g. "-t rel_ab_w_read_stats"
     keep_bt2: False          # Keep the bowtie2 files
     keep_sam: False          # Keep the sam files, set this to True if you want to run StrainPhlAn.
+    run_krona: True
     heatmap:
         level: "Species"         # Taxononomic level: Kingdom, Phylum, Class, Order, Family, Genus, Species, or Strain
         topN: 50                 # Number of top taxa to include in heatmap.

--- a/envs/Singularity.biobakery
+++ b/envs/Singularity.biobakery
@@ -11,7 +11,7 @@ From: mambaorg/micromamba:0.17.0
 		-c bioconda \
 		-c conda-forge \
 		-c biobakery \
-		python=3.7 metaphlan=4.0.0 humann=3.5 krona=2.8.1
+		python=3.7 metaphlan=4.0.2 humann=3.5 krona=2.8.1
 	micromamba clean --yes --all
 
 	humann_databases --download utility_mapping full /opt/humann --update-config yes

--- a/envs/metaphlan.yaml
+++ b/envs/metaphlan.yaml
@@ -5,5 +5,5 @@ channels:
     - defaults
     - biobakery
 dependencies:
-    - metaphlan =4.0.0
+    - metaphlan =4.0.2
     - krona =2.8.1

--- a/rules/taxonomic_profiling/kaiju.smk
+++ b/rules/taxonomic_profiling/kaiju.smk
@@ -31,14 +31,17 @@ if config["taxonomic_profile"]["kaiju"]:
     kaiju_reports = expand(str(OUTDIR/"kaiju/{sample}.kaiju.{level}.txt"), sample=SAMPLES, level=kaiju_config["levels"])
     kaiju_joined_table = expand(str(OUTDIR/"kaiju/all_samples.kaiju.{level}.txt"), level=kaiju_config["levels"])
     kaiju_area_plot = expand(str(OUTDIR/"kaiju/area_plot.kaiju.pdf"))
+
     all_outputs.extend(kaiju)
     all_outputs.extend(kaiju_reports)
-    all_outputs.append(kaiju_krona)
     all_outputs.append(kaiju_joined_table)
     #all_outputs.append(kaiju_area_plot)  # Buggy in stag 4.1
 
     citations.add(publications["Kaiju"])
-    citations.add(publications["Krona"])
+
+    if kaiju_config["run_krona"]:
+        all_outputs.append(kaiju_krona)
+        citations.add(publications["Krona"])
 
 
 rule download_kaiju_database:

--- a/rules/taxonomic_profiling/kraken2.smk
+++ b/rules/taxonomic_profiling/kraken2.smk
@@ -41,16 +41,19 @@ if config["taxonomic_profile"]["kraken2"]:
     combined_kreport = str(OUTDIR/"kraken2/all_samples.kraken2.txt")
     kraken_krona = str(OUTDIR/"kraken2/all_samples.kraken2.krona.html")
     kraken_area_plot = str(OUTDIR/"kraken2/area_plot.kraken2.pdf")
+
     all_outputs.extend(krakens)
     all_outputs.extend(kreports)
     all_outputs.extend(kreports_mpa_style)
     all_outputs.append(joined_kreport_mpa_style)
     all_outputs.append(combined_kreport)
-    all_outputs.append(kraken_krona)
-    all_outputs.append(kraken_area_plot)
-    
     citations.add(publications["Kraken2"])
-    citations.add(publications["Krona"])
+
+    if kraken2_config["run_krona"]:
+        all_outputs.append(kraken_krona)
+        all_outputs.append(kraken_area_plot)
+        citations.add(publications["Krona"])
+    
 
 
 rule download_minikraken2:

--- a/rules/taxonomic_profiling/metaphlan.smk
+++ b/rules/taxonomic_profiling/metaphlan.smk
@@ -55,7 +55,7 @@ rule metaphlan:
     conda:
         "../../envs/metaphlan.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:biobakery"+singularity_branch_tag
+        "docker://quay.io/biocontainers/metaphlan:4.0.2--pyhca03a8a_0"
     threads:
         cluster_config["metaphlan"]["n"] if "metaphlan" in cluster_config else 5
     params:
@@ -118,7 +118,7 @@ rule combine_metaphlan_tables:
     conda:
         "../../envs/metaphlan.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:biobakery"+singularity_branch_tag
+        "docker://quay.io/biocontainers/metaphlan:4.0.2--pyhca03a8a_0"
     threads:
         1
     shell:
@@ -208,7 +208,7 @@ rule create_metaphlan_krona_plots:
     conda:
         "../../envs/metaphlan.yaml"
     container:
-        "oras://ghcr.io/ctmrbio/stag-mwc:biobakery"+singularity_branch_tag
+        "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
     threads:
         1
     shell:

--- a/rules/taxonomic_profiling/metaphlan.smk
+++ b/rules/taxonomic_profiling/metaphlan.smk
@@ -29,11 +29,13 @@ if config["taxonomic_profile"]["metaphlan"] or config["functional_profile"]["hum
 
     all_outputs.append(heatmap)
     all_outputs.append(mpa_area_plot)
-    all_outputs.append(krona_plots)
     all_outputs.append(mpa_outputs)
 
     citations.add(publications["MetaPhlAn"])
-    citations.add(publications["Krona"])
+
+    if mpa_config["run_krona"]:
+        all_outputs.append(krona_plots)
+        citations.add(publications["Krona"])
 
 
 rule metaphlan:


### PR DESCRIPTION
One quick fix to allow disabling Krona-related outputs. 
Second part of this PR should have been its own PR, but we change the container for mpa4-related rules to use the official biocontainer instead of our own biobakery-container. 