### PR TITLE
Enable remote sources over HTTP/HTTPS

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -65,7 +65,7 @@ fastp:
     extra: ""
     keep_output: False       # StaG deletes fastp output files after host removal, set to True to keep them.
 remove_host:
-    db_path: "/ceph/db/kraken2/kraken2_GRCh38"              # [Required] Path to folder containing a Kraken2 database with host sequences (taxo.k2d, etc.)
+    db_path: ""              # [Required] Path to folder containing a Kraken2 database with host sequences (taxo.k2d, etc.)
     confidence: 0.1          # Kraken2 confidence parameter, normally set to 0.1
     extra: "--quick"         # Additional command line arguments to kraken2
     keep_kraken: False       # StaG deletes the kraken and kreport output files by default, set to True to keep them.

--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,7 @@ keep_local: False                    # Keep local copies of remote input files, 
 #########################
 qc_reads: True
 host_removal: True
+multiqc_report: True
 naive:
     assess_depth: False
     sketch_compare: False
@@ -55,7 +56,6 @@ mappers:
     bowtie2: False
 assembly: False
 binning: False
-multiqc_report: False
 
 
 #########################
@@ -65,7 +65,7 @@ fastp:
     extra: ""
     keep_output: False       # StaG deletes fastp output files after host removal, set to True to keep them.
 remove_host:
-    db_path: ""              # [Required] Path to folder containing a Kraken2 database with host sequences (taxo.k2d, etc.)
+    db_path: "/ceph/db/kraken2/kraken2_GRCh38"              # [Required] Path to folder containing a Kraken2 database with host sequences (taxo.k2d, etc.)
     confidence: 0.1          # Kraken2 confidence parameter, normally set to 0.1
     extra: "--quick"         # Additional command line arguments to kraken2
     keep_kraken: False       # StaG deletes the kraken and kreport output files by default, set to True to keep them.

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -38,9 +38,10 @@ header line with at least the following three columns: ``sample_id``,
 ``fastq_1``, and ``fastq_2``. An example file could look like this (columns are
 separated by TAB characters)::
 
-   sample_id  fastq_1                           fastq_2
-   ABC123     /path/to/sample1_1.fq.gz          /path/to/sample1_2.fq.gz
-   DEF456     s3://bucketname/sample_R1.fq.gz   s3://bucketname/sample_R2.fq.gz
+   sample_id  fastq_1                             fastq_2
+   ABC123     /path/to/sample1_1.fq.gz            /path/to/sample1_2.fq.gz
+   DEF456     s3://bucketname/sample_R1.fq.gz     s3://bucketname/sample_R2.fq.gz
+   GHI789     http://domain.com/sample_R1.fq.gz   http://domain.com/sample_R2.fq.gz
 
 Open ``config.yaml`` in your favorite editor and enter the path to a
 samplesheet TSV file that you have prepared in advance in the ``samplesheet``
@@ -60,8 +61,14 @@ storage systems like S3.
    available in environment variables ``AWS_ACCESS_KEY_ID`` and
    ``AWS_SECRET_ACCESS_KEY``.
 
+   Using remote files is also possible from http:// and https:// sources.
+
 It is possible to keep a local copy of remote input files in the repository
 folder after the run by setting ``keep_local: True`` in the config file.
+
+The samplesheet can be specified on the command line by utilizing Snakemake's
+built-in functionality for modifying configuration settings via the command line
+directive ``--config samplesheet=samplesheet.tsv``. 
 
 
 Configuring which tools to run

--- a/samplesheet.tsv
+++ b/samplesheet.tsv
@@ -1,0 +1,3 @@
+sample_id	fastq_1	fastq_2
+test1	https://github.com/boulund/stag-mwc_test_data/raw/master/test1_1.fq.gz	https://github.com/boulund/stag-mwc_test_data/raw/master/test1_2.fq.gz
+test2	https://github.com/boulund/stag-mwc_test_data/raw/master/test2_1.fq.gz	https://github.com/boulund/stag-mwc_test_data/raw/master/test2_2.fq.gz

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -19,14 +19,6 @@ class UserMessages():
             for message in messages:
                 print(level.upper()+":", message)
 
-    def print_info(self):
-        for message in self.info:
-            print(level.upper()+":", message)
-
-    def print_warnings(self):
-        for message in self.warn:
-            print(level.upper()+":", message)
-
     def info(self, message):
         self.messages["info"].add(message)
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -1,6 +1,7 @@
 # This file is part of StaG-mwc
 import csv
 from snakemake.remote.S3 import RemoteProvider as S3RemoteProvider
+from snakemake.remote.HTTP import RemoteProvider as HTTPRemoteProvider
  
 class UserMessages():
     """
@@ -47,35 +48,33 @@ class SampleSheet():
     def __init__(self, samplesheet, keep_local=False, endpoint_url="http://s3.amazonaws.com"):
         self.sample_info = {}
         self.S3 = S3RemoteProvider(host=endpoint_url)
+        self.HTTP = HTTPRemoteProvider()
         self.required_columns = ("sample_id", "fastq_1", "fastq_2")
+
+        def create_provider(uri):
+            if uri.startswith("s3://"):
+                return self.S3.remote(uri.lstrip("s3://"), keep_local=keep_local)
+            if uri.startswith(("http://", "https://")):
+                return self.HTTP.remote(uri.split("//", maxsplit=1)[1], keep_local=keep_local)
+            else:
+                return uri
 
         with open(samplesheet) as tsvfile:
             reader = csv.DictReader(tsvfile, delimiter="\t")
             for line, row in enumerate(reader, start=1):
                 if not all(col in row for col in self.required_columns):
                     raise ValueError(f"Missing column! {self.required_columns} are required.")
-
-                fq1_source = "local"  # For debugging
-                fq2_source = "local"  # For debugging
-                fq1 = row["fastq_1"]
-                fq2 = row["fastq_2"]
+                if row["sample_id"] in self.sample_info:
+                    raise ValueError(f"{row['sample_id']} exists more than once!")
 
                 try:
-                    if fq1.startswith("s3://"):
-                        fq1 = self.S3.remote(fq1.lstrip("s3://"), keep_local=keep_local)
-                        fq1_source = "S3"
-                    if fq2.startswith("s3://"):
-                        fq2 = self.S3.remote(fq2.lstrip("s3://"), keep_local=keep_local)
-                        fq2_source = "S3"
+                    fq1 = create_provider(row["fastq_1"])
+                    fq2 = create_provider(row["fastq_2"])
                 except AttributeError as e:
                     raise ValueError(f"Cannot parse line {line} in {samplesheet}")
                                                               
-                if row["sample_id"] in self.sample_info:
-                    raise ValueError(f"{row['sample_id']} exists more than once!")
                 self.sample_info[row["sample_id"]] = {                 
-                        "read1": fq1, "read1_src": fq1_source,
-                        "read2": fq2, "read2_src": fq2_source,
+                        "read1": fq1,
+                        "read2": fq2,
                 }                                             
         self.samples = list(self.sample_info.keys())
-
-


### PR DESCRIPTION
This PR adds the possibility to read remote source data also via HTTP/HTTPS. I also added an example samplesheet that contains URLs to the small test data set that I use when testing StaG locally, I figure this kind of makes #196 unnecessary. 