### PR TITLE
Make BAM files from mappers temporary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ situations.
 
 ## [0.6.1] Unreleased
 ### Added
+- BBMap: now outputs sorted BAM file, added options `keep_sam` and `keep_bam`.
+- Bowtie2: added option `keep_bam`.
 
 ### Fixed
 - KrakenUniq: environment variable `LC_ALL` has been added to Singularity image

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -183,6 +183,8 @@ bbmap:
     - db_name: ""              # [Required] Custom name for BBMap database
       db_path: ""              # [Required] Path to BBMap database (folder should contain a 'ref' folder)
       min_id: 0.76             # Minimum id for read alignment, BBMap default is 0.76
+      keep_sam: False          # Set to True to keep intermediary SAM file
+      keep_bam: True           # Set to False to remove bam files after counting annotations
       extra: ""                # Extra BBMap command line parameters
       counts_table:
           annotations: ""      # Tab-separated annotation file with headers, first column is full FASTA header of reference sequences
@@ -194,6 +196,7 @@ bbmap:
           extra: ""            # Extra featureCount command line parameters
 bowtie2:
     - db_prefix: ""            # [Required] Full path to Bowtie2 index (not including file extension)
+      keep_bam: True           # Set to False to remove bam files after counting annotations
       extra: ""                # Extra bowtie2 commandline parameters
       counts_table:
           annotations: ""      # Tab-separated annotation file with headers, first column is full FASTA header of reference sequences

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -350,10 +350,11 @@ BBMap
 :Tool: `BBMap`_
 :Output folder: ``bbmap/<database_name>``
 
-This module maps read using `BBMap`_. The output is in gzipped SAM format. It
-is possible to configure the mapping settings almost entirely according to
-preference, with the exception of changing the output format from gzipped SAM.
-Use the configuration parameter ``bbmap:extra`` to add any standard BBMap
+This module maps read using `BBMap`_. The output is in sorted and indexed BAM
+format (with an option to keep the intermediary SAM file used to create the
+BAM). It is possible to configure the mapping settings almost entirely
+according to preference, with the exception of changing the output format. Use
+the configuration parameter ``bbmap:extra`` to add any standard BBMap
 commandline parameter you want.
 
 Bowtie2
@@ -378,6 +379,8 @@ signifies a list)::
         - db_name: ""
           db_path: ""
           min_id: 0.76
+          keep_sam: False
+          keep_bam: True
           extra: ""
           counts_table:
               annotations: ""
@@ -397,6 +400,8 @@ configuration options, but with different settings. For example, to map against
         - db_name: "db1"
           db_path: "/path/to/db1"
           min_id: 0.76
+          keep_sam: False
+          keep_bam: True
           extra: ""
           counts_table:
               annotations: ""
@@ -409,6 +414,8 @@ configuration options, but with different settings. For example, to map against
         - db_name: "db2"
           db_path: "/path/to/db2"
           min_id: 0.76
+          keep_sam: False
+          keep_bam: True
           extra: ""
           counts_table:
               annotations: "/path/to/db2/annotations.txt"

--- a/workflow/rules/mappers/bowtie2.smk
+++ b/workflow/rules/mappers/bowtie2.smk
@@ -59,7 +59,7 @@ for bt2_config in config["bowtie2"]:
             sample=[OUTDIR/"host_removal/{sample}_1.fq.gz",
                     OUTDIR/"host_removal/{sample}_2.fq.gz"]
         output:
-            OUTDIR/"bowtie2/{db_name}/{{sample}}.bam".format(db_name=bt2_db_name)
+            OUTDIR/"bowtie2/{db_name}/{{sample}}.bam".format(db_name=bt2_db_name) if bt2_config["keep_bam"] else temp(OUTDIR/"bowtie2/{db_name}/{{sample}}.bam".format(db_name=bt2_db_name)),
         log:
             str(LOGDIR/"bowtie2/{db_name}/{{sample}}.log".format(db_name=bt2_db_name))
         message:


### PR DESCRIPTION
In order to save disk space when mapping many samples against very large references databases it can be useful to let StaG delete all the BAM files produced from the mapping step. It of course leads to having to redo the mapping again if you want to rerun annotations or any other type of downstream analysis that requires the mapping results, but at least the option is there now.

Requested by #78 