### PR TITLE
KrakenUniq: Use fuse.sh instead of reformat.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ situations.
   directories outside of Slurm job folders so that they cannot be automatically
   cleaned up if the Slurm job times out or fails before HUMAnN can clean up
   after itself.
+- KrakenUniq: Concatenate reads with BBMap's `fuse.sh` with a padding of one
+  `N` instead of interleaving the paired inputs into a single FASTA to avoid
+  KrakenUniq treating paired reads independently.
 
 ### Deprecated
 

--- a/workflow/rules/taxonomic_profiling/krakenuniq.smk
+++ b/workflow/rules/taxonomic_profiling/krakenuniq.smk
@@ -57,10 +57,12 @@ rule krakenuniq_merge_reads:
         "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
     shell:
         """
-        reformat.sh \
+        fuse.sh \
             in1={input.read1} \
             in2={input.read2} \
             out={output.fasta} \
+            pad=1 \
+            fusepairs=t \
             2> {log}
         """
 


### PR DESCRIPTION
@nilay-p discovered that KrakenUniq treated interleaved paired reads independently, and not as in the original implementation that we worked around with BBMap's `reformat.sh`. I replaced the interleaving step with a concatenation step instead, using BBMap's `fuse.sh`, which should replicate the behavior of KrakenUniq's `read_merger.pl` exactly. 