### PR TITLE
Use resources.tmpdir instead of custom solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ situations.
   input data for KrakenUniq to avoid giving KrakenUniq symlinks as input.
 
 ### Changed
-- HUMAnN3: Changed the way the temporary directory is resolved, using
+- MetaPhlAn: Updated to v4.0.6
+- HUMAnN3: Updated to v3.7
+- HUMAnN3: Changed the way the temporary directory is resolved, now using
   Snakemake's built-in `resources.tmpdir`. This should prevent HUMAnN from
   creating large temporary directories outside of Slurm job folders so that
   they cannot be automatically cleaned up if the Slurm job times out or fails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,11 @@ situations.
   input data for KrakenUniq to avoid giving KrakenUniq symlinks as input.
 
 ### Changed
-- The default tmpdir has been set to `$TMPDIR` which should evaluate to a
-  suitable temporary directory on most systems, including when executing with
-  Slurm. This is mainly to prevent HUMAnN from creating large temporary
-  directories outside of Slurm job folders so that they cannot be automatically
-  cleaned up if the Slurm job times out or fails before HUMAnN can clean up
-  after itself.
+- HUMAnN3: Changed the way the temporary directory is resolved, using
+  Snakemake's built-in `resources.tmpdir`. This should prevent HUMAnN from
+  creating large temporary directories outside of Slurm job folders so that
+  they cannot be automatically cleaned up if the Slurm job times out or fails
+  before HUMAnN can clean up after itself.
 - KrakenUniq: Concatenate reads with BBMap's `fuse.sh` with a padding of one
   `N` instead of interleaving the paired inputs into a single FASTA to avoid
   KrakenUniq treating paired reads independently.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,7 +17,6 @@ input_fn_pattern: "{sample}_{readpair}.fq.gz"
 samplesheet: ""           # Three-column samplesheet with sample_id,fastq_1,fastq_2 columns. Used instead of inputdir
 outdir: "output_dir"
 logdir: "output_dir/logs"
-tmpdir: "$TMPDIR"         # Specifying tmpdir is normally not required but tools like HUMAnN requires it. Please enter path to a temp directory e.g. /tmp or /scratch
 dbdir: "databases"        # Databases will be downloaded to this dir
 report: "StaG_report-"    # Filename prefix for report file ("-{datetime}.html" automatically appended)
 email: ""                 # Email to send status message after completed/failed run.

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -261,9 +261,11 @@ the default unit is counts per million (cpm).
    so all MetaPhlAn-associated steps are run regardless of whether it is actually
    enabled in ``config.yaml`` or not.
 
-Due to temporary disk space issues with running HUMAnN it is now a requirement
-to specify a $TMPDIR in ``config.yaml``, e.g. ``/scratch`` or ``/tmp`` depending 
-on your system's configuration.
+HUMAnN requires large amounts of temporary disk space when processing a sample
+and will automatically use a suitable temporary directory from system
+environment variable ``$TMPDIR``, using Snakemake's resources feature to
+evaluate the variable at runtime (which means it can utilize node-local
+temporary disk if executing on a compute cluster).
 
 
 Antibiotic resistance

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -31,7 +31,6 @@ citations = {publications["StaG"], publications["Snakemake"]}
 INPUTDIR = Path(config["inputdir"])
 OUTDIR = Path(config["outdir"])
 LOGDIR = Path(config["logdir"])
-TMPDIR = Path(config["tmpdir"])
 DBDIR = Path(config["dbdir"])
 all_outputs = []
 

--- a/workflow/envs/Singularity.biobakery
+++ b/workflow/envs/Singularity.biobakery
@@ -11,7 +11,7 @@ From: mambaorg/micromamba:0.17.0
 		-c bioconda \
 		-c conda-forge \
 		-c biobakery \
-		python=3.7 metaphlan=4.0.3 humann=3.6 krona=2.8.1
+		python=3.7 metaphlan=4.0.6 humann=3.7 krona=2.8.1
 	micromamba clean --yes --all
 
 	humann_databases --download utility_mapping full /opt/humann --update-config yes

--- a/workflow/envs/humann.yaml
+++ b/workflow/envs/humann.yaml
@@ -1,8 +1,7 @@
 name: stag-mwc-biobakery
 channels:
-    - biobakery
     - conda-forge
     - bioconda
     - defaults
 dependencies:
-    - humann=3.6
+    - humann=3.7

--- a/workflow/envs/humann.yaml
+++ b/workflow/envs/humann.yaml
@@ -1,5 +1,6 @@
 name: stag-mwc-biobakery
 channels:
+    - biobakery
     - conda-forge
     - bioconda
     - defaults

--- a/workflow/envs/metaphlan.yaml
+++ b/workflow/envs/metaphlan.yaml
@@ -3,7 +3,6 @@ channels:
     - conda-forge
     - bioconda
     - defaults
-    - biobakery
 dependencies:
-    - metaphlan =4.0.3
+    - metaphlan =4.0.6
     - krona =2.8.1

--- a/workflow/rules/taxonomic_profiling/metaphlan.smk
+++ b/workflow/rules/taxonomic_profiling/metaphlan.smk
@@ -56,7 +56,7 @@ rule metaphlan:
     conda:
         "../../envs/metaphlan.yaml"
     container:
-        "docker://quay.io/biocontainers/metaphlan:4.0.3--pyhca03a8a_0"
+        "docker://quay.io/biocontainers/metaphlan:4.0.6--pyhca03a8a_0"
     threads: 8
     params:
         bt2_db_dir=mpa_config["bt2_db_dir"],
@@ -118,7 +118,7 @@ rule combine_metaphlan_tables:
     conda:
         "../../envs/metaphlan.yaml"
     container:
-        "docker://quay.io/biocontainers/metaphlan:4.0.3--pyhca03a8a_0"
+        "docker://quay.io/biocontainers/metaphlan:4.0.6--pyhca03a8a_0"
     threads: 1
     shell:
         """


### PR DESCRIPTION
Improve the HUMAnN rule by using `resources.tmpdir` instead of custom solution