### PR TITLE
Improve host removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ situations.
 ### Fixed
 
 ### Changed
-
+- Preprocessing summary: Preprocessing summary script can now output a table of
+  read counts regardless of which combination of read QC and host removal is
+  used.
+  
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ situations.
 
 ## [0.7.0] Unreleased
 ### Added
+- Host removal: Bowtie2 now available as an option for host removal.
 
 ### Fixed
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -33,7 +33,9 @@ keep_local: False                    # Keep local copies of remote input files, 
 # Pipeline steps included
 #########################
 qc_reads: True
-host_removal: True
+host_removal: 
+    kraken2: True
+    bowtie2: False
 multiqc_report: True
 naive:
     assess_depth: False
@@ -61,13 +63,17 @@ fastp:
     extra: ""
     keep_output: False       # StaG deletes fastp output files after host removal, set to True to keep them.
 remove_host:
-    db_path: ""              # [Required] Path to folder containing a Kraken2 database with host sequences (taxo.k2d, etc.)
-    confidence: 0.1          # Kraken2 confidence parameter, normally set to 0.1
-    extra: "--quick"         # Additional command line arguments to kraken2
-    keep_kraken: False       # StaG deletes the kraken and kreport output files by default, set to True to keep them.
-    keep_kreport: False      # Keep the kreport files for host removal
-    keep_fastq: True         # Keep the host removed fastq files, set to False to remove them automatically.
-    keep_host_fastq: False   # Keep the host-containing fastq files, set to False to remove them automatically.
+    kraken2:
+        db_path: ""              # [Required] Path to folder containing a Kraken2 database with host sequences (taxo.k2d, etc.)
+        confidence: 0.1          # Kraken2 confidence score, float in [0,1]
+        extra: "--quick"         # Additional command line arguments to kraken2
+        keep_kraken: False       # Keep the kraken files for host removal, set to False to remove them automatically.
+        keep_kreport: False      # Keep the kreport files for host removal, set to False to remove them automatically.
+        keep_fastq: True         # Keep the host removed fastq files, set to False to remove them automatically.
+        keep_host_fastq: False   # Keep the host-containing fastq files, set to False to remove them automatically.
+    bowtie2:
+        db_path: ""              # [Required] Path to bowtie2 database to use for host removal
+        extra: "--sensitive"
 multiqc:
     extra: ""
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -69,11 +69,12 @@ remove_host:
         extra: "--quick"         # Additional command line arguments to kraken2
         keep_kraken: False       # Keep the kraken files for host removal, set to False to remove them automatically.
         keep_kreport: False      # Keep the kreport files for host removal, set to False to remove them automatically.
-        keep_fastq: True         # Keep the host removed fastq files, set to False to remove them automatically.
+        keep_fastq: True         # Keep the host-removed fastq files, set to False to remove them automatically.
         keep_host_fastq: False   # Keep the host-containing fastq files, set to False to remove them automatically.
     bowtie2:
-        db_path: ""              # [Required] Path to bowtie2 database to use for host removal
+        db_path: ""              # [Required] Path to bowtie2 database to use for host removal, including database filename prefix (no .1.bt2 etc)
         extra: "--sensitive"
+        keep_fastq: True         # Keep the host-removed fastq files, set to False to remove them automatically.
 multiqc:
     extra: ""
 

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,5 +1,6 @@
 .. _BBCountUnique: https://jgi.doe.gov/data-and-tools/bbtools/bb-tools-user-guide/calcuniqueness-guide/
 .. _FastP:  https://github.com/OpenGene/fastp
+.. _Bowtie2: https://bowtie-bio.sourceforge.net/bowtie2/index.shtml
 .. _BBMap: https://sourceforge.net/projects/bbmap/
 .. _FastQC: https://www.bioinformatics.babraham.ac.uk/projects/fastqc/
 .. _Kaiju: http://kaiju.binf.ku.dk/
@@ -21,8 +22,8 @@ Modules
 |full_name| is a workflow framework that connects several other tools. The
 basic assumption is that all analyses start with a quality control of the
 sequencing reads (using `FastP`_), followed by host sequence removal (using
-`Kraken2`_). This section of the documentation aims to describe useful details
-about the separate tools that are used in |full_name|.
+`Kraken2`_ or `Bowtie2`_). This section of the documentation aims to describe
+useful details about the separate tools that are used in |full_name|.
 
 The following subsections describe the function of each module included in
 |full_name|.  Each tool produces output in a separate subfolder inside the
@@ -52,16 +53,24 @@ reads are output into ``fastp``. Output filenames are::
 
 remove_host
 --------------
+The ``remove_host`` module can use either `Kraken2`_ or `Bowtie2`_ to classify
+reads against a database of host sequences to remove reads matching to
+non-desired host genomes.
+
+.. note::
+
+    It is possible to skip host removal. StaG then replaces the output files
+    with symlinks to the fastp output files.
+
+
 :Tool: `Kraken2`_
 :Output folder: ``host_removal``
 
-The ``remove_host`` module uses `Kraken2`_ to classify reads against a database
-of host sequences to remove reads matching to non-desired host genomes. The
-output are two sets of pairs of paired-end FASTQ files, and optionally one
-Kraken2 classification file and one Kraken2 summary report.  In addition, two
-PDF files with 1) a basic histogram plot of the proportion of host reads
-detected in each sample, and 2) a barplot of the same. A TSV table with the raw
-proportion data is also provided::
+The output from Kraken2 are two sets of pairs of paired-end FASTQ files, and
+optionally one Kraken2 classification file and one Kraken2 summary report.  In
+addition, two PDF files with 1) a basic histogram plot of the proportion of
+host reads detected in each sample, and 2) a barplot of the same. A TSV table
+with the raw proportion data is also provided::
 
     <sample>_{1,2}.fq.gz
     <sample>.host_{1,2}.fq.gz
@@ -69,10 +78,14 @@ proportion data is also provided::
     host_histogram.pdf
     host_proportions.txt
 
-.. note::
 
-    It is possible to skip host removal. StaG then replaces the output files
-    with symlinks to the fastp output files.
+:Tool: `Bowtie2`_
+:Output folder: ``host_removal``
+
+The output from Bowtie2 is a set of paired-end FASTQ files::
+
+    <sample>_{1,2}.fq.gz
+
 
 
 preprocessing_summary

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -91,9 +91,8 @@ The output from Bowtie2 is a set of paired-end FASTQ files::
 preprocessing_summary
 ---------------------
 This module summarize the number of reads passing through each preprocessing
-step and produces a summary table and a basic line plot showing the proportions
-of reads after each step. For more detailed information about read QC please
-refer to the MulitQC report.
+step and produces a summary table showing the number of reads after each step.
+For more detailed information about read QC please refer to the MulitQC report.
 
 
 multiqc

--- a/profiles/ctmr_gandalf/config.yaml
+++ b/profiles/ctmr_gandalf/config.yaml
@@ -49,7 +49,8 @@ default-resources:
   - mem_mb=10240
 set-threads:
   - fastp=20
-  - remove_host=20
+  - kraken2_remove_host=20
+  - bowtie2_remove_host=20
   - bbcountunique=4
   - sketch=8
   - kaiju=32
@@ -69,8 +70,10 @@ set-threads:
 set-resources:
   - fastp:mem_mb=20240
   - fastp:time="02:00:00"
-  - remove_host:mem_mb=10240
-  - remove_host:time="02:00:00"
+  - kraken2_remove_host:mem_mb=10240
+  - kraken2_remove_host:time="02:00:00"
+  - bowtie2_remove_host:mem_mb=10240
+  - bowtie2_remove_host:time="06:00:00"
   - kaiju:mem_mb=10240
   - kaiju:time="10:00:00"
   - kraken2:mem_mb=10240

--- a/workflow/rules/preproc/host_removal.smk
+++ b/workflow/rules/preproc/host_removal.smk
@@ -14,9 +14,9 @@ if config["host_removal"]["kraken2"] and config["host_removal"]["bowtie2"]:
 #########################################
 rh_kraken2 = config["remove_host"]["kraken2"]
 if config["host_removal"]["kraken2"]:
-    db_path = Path(rh_kraken2["db_path"])
-    if not Path(db_path/"taxo.k2d").is_file():
-        err_message = "Cannot find Kraken2 database for host sequence removal at: '{}/*.k2d'!\n".format(db_path)
+    k2_db_path = Path(rh_kraken2["db_path"])
+    if not Path(k2_db_path/"taxo.k2d").is_file():
+        err_message = "Cannot find Kraken2 database for host sequence removal at: '{}/*.k2d'!\n".format(k2_db_path)
         err_message += "Specify path to folder containing Kraken2 database for host removal in config.yaml.\n"
         raise WorkflowError(err_message)
 
@@ -125,10 +125,11 @@ if config["host_removal"]["kraken2"]:
 rh_bowtie2 = config["remove_host"]["bowtie2"]
 if config["host_removal"]["bowtie2"]:
     bt2_db_path = Path(rh_bowtie2["db_path"])
-    #if not Path(db_path).is_file():
-    #    err_message = "Cannot find Bowtie2 database for host sequence removal at: '{}'!\n".format(db_path)
-    #    err_message += "Specify path to folder containing Bowtie2 database for host removal in config.yaml.\n"
-    #    raise WorkflowError(err_message)
+    if not list(bt2_db_path.parent.glob(bt2_db_path.name+".1.bt2*")):
+        err_message = "Cannot find Bowtie2 database for host sequence removal at: '{}/'!\n".format(bt2_db_path)
+        err_message += "Specify path to folder containing Bowtie2 database for host removal in config.yaml.\n"
+        err_message += "Note that the path should not contain the '.1.bt2' suffix."
+        raise WorkflowError(err_message)
 
     bt2_filtered = expand(OUTDIR/"host_removal/{sample}_{readpair}.fq.gz",
             sample=SAMPLES,

--- a/workflow/rules/preproc/host_removal.smk
+++ b/workflow/rules/preproc/host_removal.smk
@@ -5,7 +5,9 @@ from pathlib import Path
 from snakemake.exceptions import WorkflowError
 
 
-if config["host_removal"]["kraken2"] and config["host_removal"]["bowtie2"]:
+run_k2_and_bt2 = config["host_removal"]["kraken2"] and config["host_removal"]["bowtie2"]
+
+if run_k2_and_bt2:
     err_message = "Running both Kraken2 and Bowtie2 for host removal is not supported"
     raise WorkflowError(err_message)
 
@@ -153,7 +155,7 @@ if config["host_removal"]["bowtie2"]:
         conda:
             "../../envs/metaphlan.yaml"
         container:
-            "docker://quay.io/biocontainers/metaphlan:4.0.3--pyhca03a8a_0"
+            "docker://quay.io/biocontainers/bowtie2:2.5.1--py38he00c5e5_2"
         params:
             db_path=rh_bowtie2["db_path"],
             extra=rh_bowtie2["extra"],
@@ -181,7 +183,7 @@ if config["host_removal"]["bowtie2"]:
         conda:
             "../../envs/metaphlan.yaml"
         container:
-            "docker://quay.io/biocontainers/metaphlan:4.0.3--pyhca03a8a_0"
+            "docker://quay.io/biocontainers/samtools:1.17--hd87286a_1"
         shell:
             """
             samtools view \
@@ -205,7 +207,7 @@ if config["host_removal"]["bowtie2"]:
         conda:
             "../../envs/metaphlan.yaml"
         container:
-            "docker://quay.io/biocontainers/metaphlan:4.0.3--pyhca03a8a_0"
+            "docker://quay.io/biocontainers/samtools:1.17--hd87286a_1"
         shell:
             """
             samtools view \
@@ -231,7 +233,7 @@ if config["host_removal"]["bowtie2"]:
         conda:
             "../../envs/metaphlan.yaml"
         container:
-            "docker://quay.io/biocontainers/metaphlan:4.0.3--pyhca03a8a_0"
+            "docker://quay.io/biocontainers/samtools:1.17--hd87286a_1"
         shell: 
             """
             samtools sort \
@@ -257,7 +259,7 @@ if config["host_removal"]["bowtie2"]:
         conda:
             "../../envs/metaphlan.yaml"
         container:
-            "docker://quay.io/biocontainers/metaphlan:4.0.3--pyhca03a8a_0"
+            "docker://quay.io/biocontainers/samtools:1.17--hd87286a_1"
         shell: 
             """
             samtools fastq \

--- a/workflow/rules/preproc/host_removal.smk
+++ b/workflow/rules/preproc/host_removal.smk
@@ -5,11 +5,19 @@ from pathlib import Path
 
 from snakemake.exceptions import WorkflowError
 
-rh_config = config["remove_host"]
-if config["host_removal"]:
-    db_path = Path(config["remove_host"]["db_path"])
+
+if config["host_removal"]["kraken2"] and config["host_removal"]["bowtie2"]:
+    err_message = "Running both Kraken2 and Bowtie2 for host removal is not supported"
+    raise WorkflowError(err_message)
+
+#########################################
+#              kraken2
+#########################################
+rh_kraken2 = config["remove_host"]["kraken2"]
+if config["host_removal"]["kraken2"]:
+    db_path = Path(rh_kraken2["db_path"])
     if not Path(db_path/"taxo.k2d").is_file():
-        err_message = "Cannot find database for host sequence removal at: '{}/*.k2d'!\n".format(db_path)
+        err_message = "Cannot find Kraken2 database for host sequence removal at: '{}/*.k2d'!\n".format(db_path)
         err_message += "Specify path to folder containing Kraken2 database for host removal in config.yaml.\n"
         raise WorkflowError(err_message)
 
@@ -19,7 +27,7 @@ if config["host_removal"]:
             sample=SAMPLES,
             readpair=[1,2])
     host_proportions = str(OUTDIR/"host_removal/host_proportions.txt")
-    if rh_config["keep_fastq"]:
+    if rh_kraken2["keep_fastq"]:
         all_outputs.extend(filtered_host)
     all_outputs.append(host_proportions)
 
@@ -34,12 +42,12 @@ if config["host_removal"]:
             read1=OUTDIR/"fastp/{sample}_1.fq.gz",
             read2=OUTDIR/"fastp/{sample}_2.fq.gz",
         output:
-            read1=OUTDIR/"host_removal/{sample}_1.fq.gz" if rh_config["keep_fastq"] else temp(OUTDIR/"host_removal/{sample}_1.fq.gz"),
-            read2=OUTDIR/"host_removal/{sample}_2.fq.gz" if rh_config["keep_fastq"] else temp(OUTDIR/"host_removal/{sample}_2.fq.gz"),
-            host1=OUTDIR/"host_removal/{sample}.host_1.fq.gz" if rh_config["keep_host_fastq"] else temp(OUTDIR/"host_removal/{sample}.host_1.fq.gz"),
-            host2=OUTDIR/"host_removal/{sample}.host_2.fq.gz" if rh_config["keep_host_fastq"] else temp(OUTDIR/"host_removal/{sample}.host_2.fq.gz"),
-            kraken=OUTDIR/"host_removal/{sample}.kraken" if rh_config["keep_kraken"] else temp(OUTDIR/"host_removal/{sample}.kraken"),
-            kreport=OUTDIR/"host_removal/{sample}.kreport" if rh_config["keep_kreport"] else temp(OUTDIR/"host_removal/{sample}.kreport"),
+            read1=OUTDIR/"host_removal/{sample}_1.fq.gz" if rh_kraken2["keep_fastq"] else temp(OUTDIR/"host_removal/{sample}_1.fq.gz"),
+            read2=OUTDIR/"host_removal/{sample}_2.fq.gz" if rh_kraken2["keep_fastq"] else temp(OUTDIR/"host_removal/{sample}_2.fq.gz"),
+            host1=OUTDIR/"host_removal/{sample}.host_1.fq.gz" if rh_kraken2["keep_host_fastq"] else temp(OUTDIR/"host_removal/{sample}.host_1.fq.gz"),
+            host2=OUTDIR/"host_removal/{sample}.host_2.fq.gz" if rh_kraken2["keep_host_fastq"] else temp(OUTDIR/"host_removal/{sample}.host_2.fq.gz"),
+            kraken=OUTDIR/"host_removal/{sample}.kraken" if rh_kraken2["keep_kraken"] else temp(OUTDIR/"host_removal/{sample}.kraken"),
+            kreport=OUTDIR/"host_removal/{sample}.kreport" if rh_kraken2["keep_kreport"] else temp(OUTDIR/"host_removal/{sample}.kreport"),
         log:
             stderr=str(LOGDIR/"host_removal/{sample}.kraken2.log"),
         shadow:
@@ -50,9 +58,9 @@ if config["host_removal"]:
             "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
         threads: 8
         params:
-            db=rh_config["db_path"],
-            confidence=rh_config["confidence"],
-            extra=rh_config["extra"],
+            db=rh_kraken2["db_path"],
+            confidence=rh_kraken2["confidence"],
+            extra=rh_kraken2["extra"],
             classified=lambda w: f"{OUTDIR}/host_removal/{w.sample}.host#.fq",
             unclassified=lambda w: f"{OUTDIR}/host_removal/{w.sample}#.fq",
             fq_to_compress=lambda w: f"{OUTDIR}/host_removal/{w.sample}*.fq",
@@ -112,13 +120,123 @@ if config["host_removal"]:
                 2>&1 > {log}
             """
 
-else:
+#########################################
+#              bowtie2
+#########################################
+rh_bowtie2 = config["remove_host"]["bowtie2"]
+if config["host_removal"]["bowtie2"]:
+    rule bowtie2_host_removal:
+        """Map reads against host sequence database."""
+        input:
+            read1=OUTDIR/"fastp/{sample}_1.fq.gz",
+            read2=OUTDIR/"fastp/{sample}_2.fq.gz",
+        output:
+            sam=temp(OUTDIR/"host_removal/{sample}.sam"),
+        log:
+            stdout=OUTDIR/"logs/host_removal/{sample}.bowtie2.stdout",
+            stderr=OUTDIR/"logs/host_removal/{sample}.bowtie2.stderr",
+        threads:
+            10
+        conda:
+            "envs/conda.yaml"
+        params:
+            db_path="/ceph/db/bowtie2/GRCh38_noalt_as/GRCh38_noalt_as",
+        shell:
+            """
+            bowtie2 -p 8 -x {params.db_path} \
+                -1 {input.read1} \
+                -2 {input.read2} \
+                -S {output.file} \
+                > {log.stdout} \
+                2> {log.stderr}
+            """
 
+    rule bt2_sam2bam:
+        """Convert SAM to BAM."""
+        input:
+            sam=rules.bowtie2_host_removal.output.sam,
+        output:
+            bam=temp("output/host_removal/{sample}.bam"),
+        threads:
+            10
+        conda:
+            "envs/conda.yaml"
+        shell:
+            """
+            samtools view \
+                -bS {input.sam} \
+                -o {output.bam}
+            """
+
+    rule bt2_get_unmapped_pairs:
+        """SAM-flag filter: get unmapped pairs (both reads R1 and R2 unmapped)."""
+        input:
+            bam2=rules.bt2_sam2bam.output.bam,
+        output:
+            unmapped=temp("output/host_removal/{sample}_unmapped.bam"),
+        threads:
+            10
+        conda:
+            "envs/conda.yaml"
+        shell:
+            """
+            samtools view \
+                -b \
+                -f 12 \
+                -F 256 {input.bam2} \
+                -o {output.unmapped}
+            """
+
+    rule bt2_sort_bam_files:
+        """Sort BAM file by read name ( -n ) to get paired reads."""
+        input:
+            pairs=rules.bt2_get_unmapped_pairs.output.unmapped,
+        output:
+            sorted=temp("output/sam_files/{sample}_unmapped.sorted.bam"),
+        threads:
+            10
+        conda:
+            "envs/conda.yaml"
+        shell: 
+            """
+            samtools sort \
+                -n \
+                -m 5G \
+                -@ 2 {input.pairs} \
+                -o {output.sorted}
+            """
+
+    rule bt2_get_read_pairs:
+        """Output paired reads in FASTQ format."""
+        input:
+            sorted_pairs=rules.bt2_sort_bam_files.output.sorted,
+        output:
+            pair1="output/{sample}_host_removed_1.fq.gz",
+            pair2="output/{sample}_host_removed_2.fq.gz",
+        log:
+            stderr="output/logs/{sample}.log",
+        threads:
+            10
+        conda:
+            "envs/conda.yaml"
+        shell: 
+            """
+            samtools fastq \
+                -@ 8 {input.sorted_pairs} \
+                -1 {output.pair1} \
+                -2 {output.pair2} \
+                -0 /dev/null -s /dev/null -n \
+                2> {log.stderr}
+            """
+
+#########################################
+#           skip host removal
+#########################################
+if not config["host_removal"]["kraken2"] or config["host_removal"]["bowtie2"]:
     if not config["fastp"]["keep_output"]:
         err_message = "Set fastp keep_output in config.yaml to True in order to skip host removal.\n"
         err_message += "If you want to run host removal set remove_host in config.yaml to True"
         raise WorkflowError(err_message)
-        
     
     filtered_host = expand(str(OUTDIR/"host_removal/{sample}_{readpair}.fq.gz"),
             sample=SAMPLES,

--- a/workflow/rules/preproc/preprocessing_summary.smk
+++ b/workflow/rules/preproc/preprocessing_summary.smk
@@ -1,6 +1,5 @@
 # vim: syntax=python expandtab
 # Summarize read counts passing through preprocessing.
-# TODO: Remove superfluous str conversions when Snakemake is pathlib compatible.
 from pathlib import Path 
 
 from snakemake.exceptions import WorkflowError
@@ -8,42 +7,41 @@ from snakemake.exceptions import WorkflowError
 localrules:
     preprocessing_summary
 
-if config["qc_reads"] and config["host_removal"]["kraken2"]:
-    # Add final output files from this module to 'all_outputs' from the main
-    # Snakefile scope. SAMPLES is also from the main Snakefile scope.
-    read_counts = str(OUTDIR/"preprocessing_read_counts.txt")
-    read_counts_plot = str(OUTDIR/"preprocessing_read_counts.pdf")
+# Add final output files from this module to 'all_outputs' from the main
+# Snakefile scope. SAMPLES is also from the main Snakefile scope.
+read_counts = OUTDIR/"preprocessing_read_counts.txt"
 
-    all_outputs.append(read_counts)
-    all_outputs.append(read_counts_plot)
+all_outputs.append(read_counts)
 
 
 rule preprocessing_summary:
     """Summarize read counts in preprocessing steps"""
     input:
-        fastp=expand(str(LOGDIR/"fastp/{sample}.fastp.json"), sample=SAMPLES),
-        kraken2=expand(str(LOGDIR/"host_removal/{sample}.kraken2.log"), sample=SAMPLES),
+        # Host removal fastq output is used as a proxy to indicate of when all
+        # quality control and host removal steps are completed
+        expand(OUTDIR/"host_removal/{sample}_1.fq.gz", sample=SAMPLES),
     output:
-        table=report(str(OUTDIR/"preprocessing_read_counts.txt"),
-            category="Preprocessing",
-            caption="../../report/preprocessing_summary.rst"),
-        plot=report(str(OUTDIR/"preprocessing_read_counts.pdf"),
+        table=report(OUTDIR/"preprocessing_read_counts.txt",
             category="Preprocessing",
             caption="../../report/preprocessing_summary.rst"),
     log:
-        stderr=str(LOGDIR/"preprocessing_summary.log"),
+        stdout=LOGDIR/"preprocessing_summary.log",
     conda:
         "../../envs/stag-mwc.yaml"
     container:
         "oras://ghcr.io/ctmrbio/stag-mwc:stag-mwc"+singularity_branch_tag
     threads: 1
+    params:
+        fastp_arg=lambda w: f"--fastp {LOGDIR}/fastp/*.fastp.json" if config["qc_reads"] else "",
+        kraken2_arg=lambda w: f"--kraken2 {LOGDIR}/host_removal/*.kraken2.log" if config["host_removal"]["kraken2"] else "",
+        bowtie2_arg=lambda w: f"--bowtie2 {LOGDIR}/host_removal/*.samtools.fastq.log" if config["host_removal"]["bowtie2"] else "",
     shell:
         """
         workflow/scripts/preprocessing_summary.py \
-            --fastp {input.fastp} \
-            --kraken2 {input.kraken2} \
+            {params.fastp_arg} \
+            {params.kraken2_arg} \
+            {params.bowtie2_arg} \
             --output-table {output.table} \
-            --output-plot {output.plot} \
-            2>&1 > {log.stderr}
+            > {log.stdout}
         """
 

--- a/workflow/rules/preproc/preprocessing_summary.smk
+++ b/workflow/rules/preproc/preprocessing_summary.smk
@@ -8,7 +8,7 @@ from snakemake.exceptions import WorkflowError
 localrules:
     preprocessing_summary
 
-if config["qc_reads"] and config["host_removal"]:
+if config["qc_reads"] and config["host_removal"]["kraken2"]:
     # Add final output files from this module to 'all_outputs' from the main
     # Snakefile scope. SAMPLES is also from the main Snakefile scope.
     read_counts = str(OUTDIR/"preprocessing_read_counts.txt")

--- a/workflow/scripts/preprocessing_summary.py
+++ b/workflow/scripts/preprocessing_summary.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Summarize read counts from all QC steps"""
+"""Summarize read counts from QC and host removal steps."""
 __author__ = "CTMR, Fredrik Boulund"
-__date__ = "2021"
-__version__ = "0.2"
+__date__ = "2021-2023"
+__version__ = "0.3"
 
 from sys import argv, exit
 from pathlib import Path
@@ -19,18 +19,18 @@ import pandas as pd
 def parse_args():
     desc = f"{__doc__} Copyright (c) {__author__} {__date__}. Version v{__version__}"
     parser = argparse.ArgumentParser(description=desc)
-    parser.add_argument("--fastp", metavar="sample.stderr.txt", nargs="+",
-            required=True,
-            help="fastp stderr.txt")
+    parser.add_argument("--fastp", metavar="sample.json", nargs="+",
+            help="fastp JSON output file.")
     parser.add_argument("--kraken2", metavar="sample.kraken2.log", nargs="+",
-            required=True,
-            help="Kraken2 log output")
+            help="Kraken2 log output.")
+    parser.add_argument("--bowtie2", metavar="sample.samtools.fastq.log", nargs="+",
+            help="Bowtie2 samtools fastq log output.")
     parser.add_argument("-o", "--output-table", metavar="TSV",
             default="read_processing_summary.txt",
-            help="filename of output table in tsv format [%(default)s].")
+            help="Filename of output table in tsv format [%(default)s].")
     parser.add_argument("-p", "--output-plot", metavar="PDF",
-            default="read_processing_summary.pdf",
-            help="filename of output table in PDF format [%(default)s].")
+            default="",
+            help="Filename of output table in PDF format [%(default)s].")
 
     if len(argv) < 2:
         parser.print_help()
@@ -39,13 +39,30 @@ def parse_args():
     return parser.parse_args()
 
 
+def parse_bowtie2_samtools_fastq_logs(logfiles):
+    for logfile in logfiles:
+        with open(logfile) as f:
+            sample_name = Path(logfile).stem.split(".")[0]
+            for line in f:
+                if not line.startswith("[M::bam2fq_mainloop]"):
+                    raise ValueError
+                if "bam2fq_mainloop] processed" in line:
+                    yield {
+                        "Sample": sample_name,
+                        "after_bowtie2_host_removal": int(int(line.split()[2])/2),  # /2 because bowtie2 counts both pairs
+                    }
+
+
 def parse_kraken2_logs(logfiles):
     for logfile in logfiles:
         with open(logfile) as f:
             sample_name = Path(logfile).stem.split(".")[0]
             for line in f:
                 if " unclassified" in line:
-                    yield {"Sample": sample_name, "after_host_removal": int(line.strip().split()[0])}
+                    yield {
+                        "Sample": sample_name,
+                        "after_kraken2_host_removal": int(line.strip().split()[0]),
+                    }
 
 
 def parse_fastp_logs(logfiles):
@@ -60,35 +77,49 @@ def parse_fastp_logs(logfiles):
                 "duplication": float(fastp_data["duplication"]["rate"]),
             }
 
+
 if __name__ == "__main__":
     args = parse_args()
 
-    read_qc = list(parse_fastp_logs(args.fastp))
-    host_removal = list(parse_kraken2_logs(args.kraken2))
+    dfs = {
+        "fastp": pd.DataFrame(),
+        "kraken2": pd.DataFrame(),
+        "bowtie2": pd.DataFrame(),
+    }
 
-    df_read_qc = pd.DataFrame(read_qc).set_index("Sample")
-    df_host_removal = pd.DataFrame(host_removal).set_index("Sample")
+    if args.fastp:
+        data_fastp = list(parse_fastp_logs(args.fastp))
+        dfs["fastp"] = pd.DataFrame(data_fastp).set_index("Sample")
+    if args.kraken2:
+        data_kraken2 = list(parse_kraken2_logs(args.kraken2))
+        dfs["kraken2"] = pd.DataFrame(data_kraken2).set_index("Sample")
+    if args.bowtie2:
+        data_bowtie2 = list(parse_bowtie2_samtools_fastq_logs(args.bowtie2))
+        dfs["bowtie2"] = pd.DataFrame(data_bowtie2).set_index("Sample")
 
-    final_column_order = [
+    df = pd.concat(dfs.values(), axis="columns")
+
+    column_order = [
         "duplication",
         "before_fastp",
         "after_fastp",
-        "after_host_removal",
+        "after_kraken2_host_removal",
+        "after_bowtie2_host_removal",
     ]
-    df = df_read_qc.join(df_host_removal)[final_column_order]
-
-    fig, ax = plt.subplots(figsize=(6, 5))
-    df[final_column_order[1:]]\
-        .div(df["before_fastp"], axis=0)\
-        .transpose()\
-        .plot(kind="line", style=".-", ax=ax)
-    ax.set_title("Proportion reads passing through QC and host removal")
-    ax.set_xlabel("Stage")
-    ax.set_ylabel("% reads")
-    handles, labels = ax.get_legend_handles_labels()
-    ax.legend(handles, labels, loc="upper left", bbox_to_anchor=(0, -0.1))
-    fig.savefig(args.output_plot, bbox_inches="tight")
+    final_columns = [c for c in column_order if c in df.columns]
+    df = df[final_columns]
 
     df.to_csv(args.output_table, sep="\t")
 
+    if args.output_plot:
+        fig, ax = plt.subplots(figsize=(6, 5))
+        df[final_columns[1:]]\
+            .transpose()\
+            .plot(kind="line", style=".-", ax=ax)
+        ax.set_title("Reads passing through QC and host removal")
+        ax.set_xlabel("Stage")
+        ax.set_ylabel("Reads")
+        handles, labels = ax.get_legend_handles_labels()
+        ax.legend(handles, labels, loc="upper left", bbox_to_anchor=(0, -0.1))
+        fig.savefig(args.output_plot, bbox_inches="tight")
 


### PR DESCRIPTION
Add bowtie2 as an option for host removal.

I have been thinking of ways to do host removal with both kraken2 and bowtie2 possible. The idea is that kraken2 runs quickly to remove the majority of reads, and then bowtie2 runs to scrub the remaining leftovers. I need to benchmark to see if it is worthwhile to implement, however. I guess it will only be meaningful if it substantially decreases the total time needed to run host removal compared to just running bowtie2 directly. 

To finish this PR I would like to have updated the read processing summary script so it can summarize read counts after any combination of fastp, kraken2, and bowtie2 preprocessing. As it is currently implemented it can only run if both fastp and kraken2 are utilized. 